### PR TITLE
Add replay path that bypasses side effects

### DIFF
--- a/src/test/java/com/can/core/CacheEngineReplayTest.java
+++ b/src/test/java/com/can/core/CacheEngineReplayTest.java
@@ -1,0 +1,49 @@
+package com.can.core;
+
+import com.can.aof.AppendOnlyFile;
+import com.can.codec.StringCodec;
+import com.can.pubsub.Broker;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CacheEngineReplayTest {
+
+    @Test
+    void replaySetSkipsSideEffects() throws Exception {
+        File temp = File.createTempFile("aof-test", ".log");
+        temp.deleteOnExit();
+        var codec = StringCodec.UTF8;
+        AtomicInteger published = new AtomicInteger();
+        try (AppendOnlyFile<String, String> aof = new AppendOnlyFile<>(temp, codec, codec, false);
+             Broker broker = new Broker();
+             AutoCloseable ignored = broker.subscribe("keyspace:set", payload -> published.incrementAndGet());
+             CacheEngine<String, String> engine = CacheEngine.<String, String>builder(codec, codec)
+                     .aof(aof)
+                     .broker(broker)
+                     .build()) {
+            long expireAt = System.currentTimeMillis() + 5_000;
+            engine.replay(new byte[]{'S'}, codec.encode("foo"), codec.encode("bar"), expireAt);
+            assertEquals("bar", engine.get("foo"));
+            Thread.sleep(50);
+            assertEquals(0, published.get());
+        }
+        assertEquals(0L, temp.length());
+    }
+
+    @Test
+    void replaySkipsExpiredEntriesAndRemovesExistingValue() throws Exception {
+        var codec = StringCodec.UTF8;
+        try (CacheEngine<String, String> engine = CacheEngine.<String, String>builder(codec, codec).build()) {
+            engine.set("foo", "live");
+            long expiredAt = System.currentTimeMillis() - 1_000;
+            engine.replay(new byte[]{'S'}, codec.encode("foo"), codec.encode("stale"), expiredAt);
+            assertEquals(0, engine.size());
+            assertFalse(engine.exists("foo"));
+            assertNull(engine.get("foo"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a replay-specific insertion path in `CacheEngine` that updates in-memory state only and skips expired records
- cover replay behaviour with tests that guard against AOF rewrites, broker publications, and resurrection of expired data

## Testing
- ./mvnw test *(fails: unable to download Maven wrapper due to network restrictions)*
- mvn test *(fails: missing parent POM because dependencies cannot be fetched in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2ce0018483238f1fd2fc928fdc38