### PR TITLE
Support configurable AOF replay path

### DIFF
--- a/src/main/java/com/can/config/AppConfig.java
+++ b/src/main/java/com/can/config/AppConfig.java
@@ -52,6 +52,7 @@ public class AppConfig {
             @Value("${app.cache.segments:8}") int segments,
             @Value("${app.cache.maxCapacity:10000}") int maxCap,
             @Value("${app.cache.cleanerPollMillis:100}") long pollMs,
+            @Value("${app.aof.path:data.aof}") String path,
             AppendOnlyFile<String,String> aof,
             MetricsRegistry metrics,
             Broker broker
@@ -62,7 +63,7 @@ public class AppConfig {
                 .build();
 
         // Açılışta AOF replay
-        AppendOnlyFile.replay(new File(System.getProperty("user.dir"), "data.aof"), engine);
+        AppendOnlyFile.replay(new File(path), engine);
         return engine;
     }
 

--- a/src/test/java/com/can/config/AppConfigAofPathTest.java
+++ b/src/test/java/com/can/config/AppConfigAofPathTest.java
@@ -1,0 +1,37 @@
+package com.can.config;
+
+import com.can.core.CacheEngine;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AppConfigAofPathTest {
+
+    @Test
+    void replaysDataFromCustomPath() throws IOException {
+        Path aofFile = Files.createTempFile("can-cache-test", ".aof");
+        String key = Base64.getEncoder().encodeToString("foo".getBytes(StandardCharsets.UTF_8));
+        String value = Base64.getEncoder().encodeToString("bar".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(aofFile, "S " + key + " " + value + " 0\n");
+
+        try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext()) {
+            TestPropertyValues.of(
+                    "app.aof.path=" + aofFile,
+                    "app.aof.fsyncEvery=false"
+            ).applyTo(ctx);
+            ctx.register(AppConfig.class);
+            ctx.refresh();
+
+            CacheEngine<String, String> engine = ctx.getBean(CacheEngine.class);
+            assertEquals("bar", engine.get("foo"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- inject the configured AOF path into the cacheEngine bean and replay data from that location
- add an integration test that ensures cache data is reloaded when a custom AOF file is provided

## Testing
- mvn test *(fails: cannot download dependencies from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2cce41708323a44717a3966446e0