### PR TITLE
Prevent ConsistentHashRing replica lookup loops

### DIFF
--- a/src/main/java/com/can/cluster/ConsistentHashRing.java
+++ b/src/main/java/com/can/cluster/ConsistentHashRing.java
@@ -1,7 +1,9 @@
 package com.can.cluster;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -21,16 +23,26 @@ public final class ConsistentHashRing<N> {
         for (int i = 0; i < vnodes; i++) ring.remove(hash.hash(join(idBytes, i)));
     }
     public synchronized List<N> getReplicas(byte[] key, int rf) {
-        var out = new ArrayList<N>(rf);
-        if (ring.isEmpty()) return out;
+        var out = new ArrayList<N>(Math.max(0, Math.min(rf, ring.size())));
+        if (rf <= 0 || ring.isEmpty()) return out;
+
         int h = hash.hash(key);
-        var tail = ring.tailMap(h);
-        var it = tail.isEmpty()? ring.values().iterator() : tail.values().iterator();
-        while (out.size() < rf) {
-            if (!it.hasNext()) it = ring.values().iterator();
-            N n = it.next();
-            if (out.isEmpty() || out.get(out.size()-1) != n) out.add(n);
+        Set<N> unique = new LinkedHashSet<>();
+
+        SortedMap<Integer, N> tail = ring.tailMap(h);
+        for (N node : tail.values()) {
+            unique.add(node);
+            if (unique.size() >= rf) break;
         }
+
+        if (unique.size() < rf) {
+            for (N node : ring.headMap(h).values()) {
+                unique.add(node);
+                if (unique.size() >= rf) break;
+            }
+        }
+
+        out.addAll(unique);
         return out;
     }
     private static byte[] join(byte[] id, int i){ return (new String(id)+"#"+i).getBytes(); }

--- a/src/test/java/com/can/cluster/ConsistentHashRingTest.java
+++ b/src/test/java/com/can/cluster/ConsistentHashRingTest.java
@@ -1,0 +1,26 @@
+package com.can.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ConsistentHashRingTest {
+
+    private static final HashFn SIMPLE_HASH = key -> Arrays.hashCode(key);
+
+    @Test
+    void returnsAvailableNodesWhenReplicationFactorExceedsUniqueNodes() {
+        ConsistentHashRing<String> ring = new ConsistentHashRing<>(SIMPLE_HASH, 3);
+        ring.addNode("node-1", "node-1".getBytes(StandardCharsets.UTF_8));
+
+        List<String> replicas = ring.getReplicas("key".getBytes(StandardCharsets.UTF_8), 5);
+
+        assertEquals(1, replicas.size(), "Only available nodes should be returned");
+        assertIterableEquals(List.of("node-1"), replicas);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the consistent hash ring stops after visiting each node once and skips duplicate replicas
- add a regression test confirming a single-node ring handles replication factors greater than the node count

## Testing
- ./mvnw test *(fails: unable to download Maven distribution in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2ccbf5188323b7b371bdc0c6a990