### PR TITLE
Add TinyLFU eviction policy and configurable cache eviction

### DIFF
--- a/src/main/java/com/can/config/AppConfig.java
+++ b/src/main/java/com/can/config/AppConfig.java
@@ -7,6 +7,7 @@ import com.can.cluster.HashFn;
 import com.can.cluster.Node;
 import com.can.codec.StringCodec;
 import com.can.core.CacheEngine;
+import com.can.core.EvictionPolicyType;
 import com.can.metric.MetricsRegistry;
 import com.can.metric.MetricsReporter;
 import com.can.pubsub.Broker;
@@ -52,6 +53,7 @@ public class AppConfig {
             @Value("${app.cache.segments:8}") int segments,
             @Value("${app.cache.maxCapacity:10000}") int maxCap,
             @Value("${app.cache.cleanerPollMillis:100}") long pollMs,
+            @Value("${app.cache.evictionPolicy:LRU}") String evictionPolicy,
             @Value("${app.aof.path:data.aof}") String path,
             AppendOnlyFile<String,String> aof,
             MetricsRegistry metrics,
@@ -59,6 +61,7 @@ public class AppConfig {
     ) {
         var engine = CacheEngine.<String,String>builder(StringCodec.UTF8, StringCodec.UTF8)
                 .segments(segments).maxCapacity(maxCap).cleanerPollMillis(pollMs)
+                .evictionPolicy(EvictionPolicyType.fromConfig(evictionPolicy))
                 .aof(aof).metrics(metrics).broker(broker)
                 .build();
 

--- a/src/main/java/com/can/core/EvictionPolicy.java
+++ b/src/main/java/com/can/core/EvictionPolicy.java
@@ -1,0 +1,52 @@
+package com.can.core;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Abstraction that encapsulates admission and eviction behaviour for a cache segment.
+ * Implementations may track access history or frequency statistics to decide whether
+ * an entry should be admitted and which victim, if any, should be evicted.
+ */
+interface EvictionPolicy<K>
+{
+    /** Records that the given key has been accessed (hit or set). */
+    void recordAccess(K key);
+
+    /**
+     * Called when a new key is about to be inserted into the segment.
+     *
+     * @param key       the candidate key that should be considered for admission
+     * @param map       current storage map for the segment (access-order)
+     * @param capacity  maximum number of entries allowed in the segment
+     * @return decision describing whether the key should be admitted and an optional victim
+     */
+    AdmissionDecision<K> admit(K key, LinkedHashMap<K, CacheValue> map, int capacity);
+
+    /** Signals that the given key has been removed from the segment. */
+    void onRemove(K key);
+
+    /** Result returned from {@link #admit(Object, LinkedHashMap, int)}. */
+    final class AdmissionDecision<K>
+    {
+        private static final AdmissionDecision<?> REJECT = new AdmissionDecision<>(false, null);
+        private static final AdmissionDecision<?> ADMIT_NO_EVICTION = new AdmissionDecision<>(true, null);
+
+        private final boolean admit;
+        private final K evictKey;
+
+        private AdmissionDecision(boolean admit, K evictKey) {
+            this.admit = admit;
+            this.evictKey = evictKey;
+        }
+
+        public boolean admit(){ return admit; }
+        public K evictKey(){ return evictKey; }
+
+        @SuppressWarnings("unchecked")
+        static <K> AdmissionDecision<K> reject(){ return (AdmissionDecision<K>) REJECT; }
+        @SuppressWarnings("unchecked")
+        static <K> AdmissionDecision<K> admit(){ return (AdmissionDecision<K>) ADMIT_NO_EVICTION; }
+        static <K> AdmissionDecision<K> admit(K evictKey){ return new AdmissionDecision<>(true, evictKey); }
+    }
+}
+

--- a/src/main/java/com/can/core/EvictionPolicyType.java
+++ b/src/main/java/com/can/core/EvictionPolicyType.java
@@ -1,0 +1,35 @@
+package com.can.core;
+
+import java.util.Locale;
+
+public enum EvictionPolicyType
+{
+    LRU {
+        @Override
+        public <K> EvictionPolicy<K> create(int capacity)
+        {
+            return new LruEvictionPolicy<>();
+        }
+    },
+    TINY_LFU {
+        @Override
+        public <K> EvictionPolicy<K> create(int capacity)
+        {
+            return new TinyLfuEvictionPolicy<>(capacity);
+        }
+    };
+
+    public abstract <K> EvictionPolicy<K> create(int capacity);
+
+    public static EvictionPolicyType fromConfig(String value)
+    {
+        if (value == null || value.isBlank()) return LRU;
+        String normalized = value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
+        try {
+            return EvictionPolicyType.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Unknown eviction policy: " + value, ex);
+        }
+    }
+}
+

--- a/src/main/java/com/can/core/LruEvictionPolicy.java
+++ b/src/main/java/com/can/core/LruEvictionPolicy.java
@@ -1,0 +1,20 @@
+package com.can.core;
+
+import java.util.LinkedHashMap;
+
+final class LruEvictionPolicy<K> implements EvictionPolicy<K>
+{
+    @Override public void recordAccess(K key){}
+
+    @Override
+    public AdmissionDecision<K> admit(K key, LinkedHashMap<K, CacheValue> map, int capacity)
+    {
+        if (map.size() < capacity) return AdmissionDecision.admit();
+        if (map.isEmpty()) return AdmissionDecision.admit();
+        K eldest = map.entrySet().iterator().next().getKey();
+        return AdmissionDecision.admit(eldest);
+    }
+
+    @Override public void onRemove(K key){}
+}
+

--- a/src/main/java/com/can/core/TinyLfuEvictionPolicy.java
+++ b/src/main/java/com/can/core/TinyLfuEvictionPolicy.java
@@ -1,0 +1,124 @@
+package com.can.core;
+
+import java.util.LinkedHashMap;
+
+final class TinyLfuEvictionPolicy<K> implements EvictionPolicy<K>
+{
+    private static final int[] SEEDS = {0x7f4a7c15, 0x9e3779b9, 0xc2b2ae35, 0x165667b1};
+
+    private final FrequencySketch sketch;
+    private final int[] samples;
+    private int index;
+    private int count;
+
+    TinyLfuEvictionPolicy(int capacity)
+    {
+        this.samples = new int[determineSampleSize(capacity)];
+        this.sketch = new FrequencySketch(samples.length == 0 ? 16 : samples.length);
+    }
+
+    private static int determineSampleSize(int capacity)
+    {
+        int base = Math.max(1, capacity);
+        int size = base * 16;
+        size = Math.max(size, 256);
+        size = Math.min(size, 1 << 16);
+        return size;
+    }
+
+    @Override
+    public void recordAccess(K key)
+    {
+        int hash = spread(key.hashCode());
+        if (samples.length == 0)
+        {
+            sketch.increment(hash);
+            return;
+        }
+        if (count >= samples.length)
+        {
+            int oldHash = samples[index];
+            sketch.decrement(oldHash);
+        }
+        else
+        {
+            count++;
+        }
+        samples[index] = hash;
+        index++;
+        if (index == samples.length) index = 0;
+        sketch.increment(hash);
+    }
+
+    @Override
+    public AdmissionDecision<K> admit(K key, LinkedHashMap<K, CacheValue> map, int capacity)
+    {
+        if (map.size() < capacity) return AdmissionDecision.admit();
+        if (map.isEmpty()) return AdmissionDecision.admit();
+        K victimKey = map.entrySet().iterator().next().getKey();
+        int candidateFreq = sketch.estimate(spread(key.hashCode()));
+        int victimFreq = sketch.estimate(spread(victimKey.hashCode()));
+        if (candidateFreq > victimFreq)
+        {
+            return AdmissionDecision.admit(victimKey);
+        }
+        return AdmissionDecision.reject();
+    }
+
+    @Override public void onRemove(K key){}
+
+    private static int spread(int hash)
+    {
+        hash ^= (hash >>> 16);
+        hash *= 0x7feb352d;
+        hash ^= (hash >>> 15);
+        hash *= 0x846ca68b;
+        hash ^= (hash >>> 16);
+        return hash;
+    }
+
+    private static final class FrequencySketch
+    {
+        private final int[] table;
+        private final int mask;
+
+        FrequencySketch(int size)
+        {
+            int length = 1;
+            while (length < size) length <<= 1;
+            this.table = new int[length];
+            this.mask = length - 1;
+        }
+
+        void increment(int hash)
+        {
+            for (int seed : SEEDS)
+            {
+                int idx = (hash ^ seed) & mask;
+                if (table[idx] < 255) table[idx]++;
+            }
+        }
+
+        void decrement(int hash)
+        {
+            for (int seed : SEEDS)
+            {
+                int idx = (hash ^ seed) & mask;
+                if (table[idx] > 0) table[idx]--;
+            }
+        }
+
+        int estimate(int hash)
+        {
+            int min = Integer.MAX_VALUE;
+            for (int seed : SEEDS)
+            {
+                int idx = (hash ^ seed) & mask;
+                int val = table[idx];
+                if (val < min) min = val;
+            }
+            return min == Integer.MAX_VALUE ? 0 : min;
+        }
+    }
+}
+

--- a/src/test/java/com/can/core/CacheEngineEvictionPolicyTest.java
+++ b/src/test/java/com/can/core/CacheEngineEvictionPolicyTest.java
@@ -1,0 +1,41 @@
+package com.can.core;
+
+import com.can.codec.StringCodec;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CacheEngineEvictionPolicyTest
+{
+    @Test
+    void builderDefaultsToLru()
+    {
+        try (CacheEngine<String,String> engine = CacheEngine.<String,String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                .segments(1).maxCapacity(2)
+                .build())
+        {
+            engine.set("hot", "v");
+            engine.set("cold-0", "v");
+            engine.set("cold-1", "v");
+            assertNull(engine.get("hot"));
+        }
+    }
+
+    @Test
+    void tinyLfuSelectionRetainsHotKeys()
+    {
+        try (CacheEngine<String,String> engine = CacheEngine.<String,String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                .segments(1).maxCapacity(2)
+                .evictionPolicy(EvictionPolicyType.TINY_LFU)
+                .build())
+        {
+            engine.set("hot", "v");
+            for (int i=0;i<128;i++) assertEquals("v", engine.get("hot"));
+            engine.set("cold-0", "v");
+            engine.set("cold-1", "v");
+            assertEquals("v", engine.get("hot"));
+            assertNull(engine.get("cold-1"));
+        }
+    }
+}
+

--- a/src/test/java/com/can/core/CacheSegmentEvictionPolicyTest.java
+++ b/src/test/java/com/can/core/CacheSegmentEvictionPolicyTest.java
@@ -1,0 +1,34 @@
+package com.can.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CacheSegmentEvictionPolicyTest
+{
+    @Test
+    void tinyLfuRejectsColdKeysUnderSkew()
+    {
+        CacheSegment<String> lru = new CacheSegment<>(2, new LruEvictionPolicy<>());
+        CacheSegment<String> tiny = new CacheSegment<>(2, new TinyLfuEvictionPolicy<>(2));
+
+        assertTrue(lru.put("hot", value()));
+        assertTrue(tiny.put("hot", value()));
+        for (int i=0;i<128;i++) assertNotNull(tiny.get("hot"));
+
+        int lruAdmitted = 0, tinyAdmitted = 0;
+        for (int i=0;i<64;i++)
+        {
+            String cold = "cold-" + i;
+            if (lru.put(cold, value())) lruAdmitted++;
+            if (tiny.put(cold, value())) tinyAdmitted++;
+        }
+
+        assertTrue(lruAdmitted > tinyAdmitted, "TinyLFU should admit fewer cold keys");
+        assertNull(lru.get("hot"));
+        assertNotNull(tiny.get("hot"));
+    }
+
+    private static CacheValue value(){ return new CacheValue(new byte[]{1}, 0L); }
+}
+


### PR DESCRIPTION
## Summary
- introduce an EvictionPolicy abstraction with an LRU implementation as the default
- add a TinyLFU policy that uses a frequency sketch and sampling ring buffer for admission decisions
- wire the CacheEngine builder and Spring configuration to choose the eviction strategy and update CacheSegment to delegate to the chosen policy
- add regression tests to exercise the new policies under skewed workloads

## Testing
- `mvn test` *(fails: unable to reach repo.maven.apache.org to download Maven parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cf305981348323bf449d62e23c4676