### PR TITLE
Refactor configuration to use typed properties

### DIFF
--- a/src/main/java/com/can/CanCacheApplication.java
+++ b/src/main/java/com/can/CanCacheApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class CanCacheApplication {
 
-    static void main(String... args)
-    {
+    public static void main(String... args) {
         SpringApplication.run(CanCacheApplication.class, args);
-	}
+    }
 }

--- a/src/main/java/com/can/config/AppProperties.java
+++ b/src/main/java/com/can/config/AppProperties.java
@@ -1,0 +1,121 @@
+package com.can.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app")
+public class AppProperties {
+
+    private final Metrics metrics = new Metrics();
+    private final Aof aof = new Aof();
+    private final Cache cache = new Cache();
+    private final Cluster cluster = new Cluster();
+
+    public Metrics getMetrics() {
+        return metrics;
+    }
+
+    public Aof getAof() {
+        return aof;
+    }
+
+    public Cache getCache() {
+        return cache;
+    }
+
+    public Cluster getCluster() {
+        return cluster;
+    }
+
+    public static class Metrics {
+        private long reportIntervalSeconds = 5L;
+
+        public long getReportIntervalSeconds() {
+            return reportIntervalSeconds;
+        }
+
+        public void setReportIntervalSeconds(long reportIntervalSeconds) {
+            this.reportIntervalSeconds = reportIntervalSeconds;
+        }
+    }
+
+    public static class Aof {
+        private String path = "data.aof";
+        private boolean fsyncEvery = true;
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public boolean isFsyncEvery() {
+            return fsyncEvery;
+        }
+
+        public void setFsyncEvery(boolean fsyncEvery) {
+            this.fsyncEvery = fsyncEvery;
+        }
+    }
+
+    public static class Cache {
+        private int segments = 8;
+        private int maxCapacity = 10_000;
+        private long cleanerPollMillis = 100L;
+        private String evictionPolicy = "LRU";
+
+        public int getSegments() {
+            return segments;
+        }
+
+        public void setSegments(int segments) {
+            this.segments = segments;
+        }
+
+        public int getMaxCapacity() {
+            return maxCapacity;
+        }
+
+        public void setMaxCapacity(int maxCapacity) {
+            this.maxCapacity = maxCapacity;
+        }
+
+        public long getCleanerPollMillis() {
+            return cleanerPollMillis;
+        }
+
+        public void setCleanerPollMillis(long cleanerPollMillis) {
+            this.cleanerPollMillis = cleanerPollMillis;
+        }
+
+        public String getEvictionPolicy() {
+            return evictionPolicy;
+        }
+
+        public void setEvictionPolicy(String evictionPolicy) {
+            this.evictionPolicy = evictionPolicy;
+        }
+    }
+
+    public static class Cluster {
+        private int virtualNodes = 64;
+        private int replicationFactor = 1;
+
+        public int getVirtualNodes() {
+            return virtualNodes;
+        }
+
+        public void setVirtualNodes(int virtualNodes) {
+            this.virtualNodes = virtualNodes;
+        }
+
+        public int getReplicationFactor() {
+            return replicationFactor;
+        }
+
+        public void setReplicationFactor(int replicationFactor) {
+            this.replicationFactor = replicationFactor;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated `AppProperties` configuration properties bean to capture metrics, AOF, cache and cluster settings
- refactor `AppConfig` to rely on constructor-injected `AppProperties` for building beans via Spring dependency injection
- tidy the Spring Boot entry point signature in `CanCacheApplication`

## Testing
- `./mvnw test` *(fails: wrapper cannot download Maven distribution in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd391f568832390cf2b9c4c50f06a