### PR TITLE
Fix AdmissionDecision method name clash

### DIFF
--- a/src/main/java/com/can/core/CacheSegment.java
+++ b/src/main/java/com/can/core/CacheSegment.java
@@ -49,7 +49,7 @@ final class CacheSegment<K>
 
             if (!force) {
                 EvictionPolicy.AdmissionDecision<K> decision = policy.admit(key, map, capacity);
-                if (!decision.admit()) {
+                if (!decision.shouldAdmit()) {
                     return false;
                 }
                 K victim = decision.evictKey();

--- a/src/main/java/com/can/core/EvictionPolicy.java
+++ b/src/main/java/com/can/core/EvictionPolicy.java
@@ -39,7 +39,7 @@ interface EvictionPolicy<K>
             this.evictKey = evictKey;
         }
 
-        public boolean admit(){ return admit; }
+        public boolean shouldAdmit(){ return admit; }
         public K evictKey(){ return evictKey; }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- rename the boolean accessor on `EvictionPolicy.AdmissionDecision` to `shouldAdmit` to avoid erasure conflicts
- update `CacheSegment` to use the renamed accessor

## Testing
- ./mvnw -q -DskipTests *(fails: unable to download Maven distribution in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cffd1b04648323879cf5429b56892b