### PR TITLE
Add comprehensive annotated unit tests

### DIFF
--- a/src/test/java/com/can/CanCacheApplicationTests.java
+++ b/src/test/java/com/can/CanCacheApplicationTests.java
@@ -3,6 +3,7 @@ package com.can;
 import com.can.cluster.ClusterClient;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -13,8 +14,15 @@ class CanCacheApplicationTests {
     @Inject
     ClusterClient<String, String> cluster;
 
-    @Test
-    void clusterClientIsAvailable() {
-        assertNotNull(cluster);
+    @Nested
+    class ContainerWiring {
+        /**
+         * Quarkus DI konteyneri AppConfig tarafından üretilen ClusterClient bean'ini sağlar.
+         * Uygulama ayağa kalktığında bu bean'in hazır olduğunu kontrol ederek modüller arası entegrasyonu doğrularız.
+         */
+        @Test
+        void clusterClientIsAvailable() {
+            assertNotNull(cluster);
+        }
     }
 }

--- a/src/test/java/com/can/cluster/ClusterClientBehaviourTest.java
+++ b/src/test/java/com/can/cluster/ClusterClientBehaviourTest.java
@@ -1,0 +1,104 @@
+package com.can.cluster;
+
+import com.can.codec.StringCodec;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Küme yapısı sabit hash ile replikalar seçer ve ClusterClient istekleri ilgili düğümlere yayınlar.
+ * Testler hem halka mantığını hem de istemci delegasyonunu adım adım açıklar.
+ */
+class ClusterClientBehaviourTest {
+
+    private static final HashFn SIMPLE_HASH = key -> java.util.Arrays.hashCode(key);
+
+    @Nested
+    class RingSelection {
+        /**
+         * ConsistentHashRing replikaları istenen sayıda benzersiz düğüm olarak döndürür.
+         * Hash sırasının sonunda wrap-around yaparak listeyi tamamlar.
+         */
+        @Test
+        void returnsReplicasInRingOrder() {
+            ConsistentHashRing<String> ring = new ConsistentHashRing<>(SIMPLE_HASH, 3);
+            ring.addNode("node-1", "node-1".getBytes());
+            ring.addNode("node-2", "node-2".getBytes());
+            ring.addNode("node-3", "node-3".getBytes());
+
+            List<String> replicas = ring.getReplicas("key".getBytes(), 2);
+            assertEquals(2, replicas.size());
+            assertTrue(replicas.contains("node-1") || replicas.contains("node-2") || replicas.contains("node-3"));
+
+            List<String> more = ring.getReplicas("key".getBytes(), 5);
+            assertEquals(3, more.size(), "Toplam düğüm sayısından fazla istek benzersiz düğümler döndürmeli");
+        }
+    }
+
+    @Nested
+    class ClientDelegation {
+        /**
+         * ClusterClient aynı anahtarı tüm replikalara gönderir; get ilk başarılı yanıtı döndürür.
+         * delete ise herhangi bir düğümde başarılı olursa true döndürmelidir.
+         */
+        @Test
+        void replicatesOperationsAcrossNodes() {
+            ConsistentHashRing<Node<String, String>> ring = new ConsistentHashRing<>(SIMPLE_HASH, 1);
+            RecordingNode nodeA = new RecordingNode("A");
+            RecordingNode nodeB = new RecordingNode("B");
+            ring.addNode(nodeA, nodeA.id().getBytes());
+            ring.addNode(nodeB, nodeB.id().getBytes());
+
+            ClusterClient<String, String> client = new ClusterClient<>(ring, 2, StringCodec.UTF8);
+
+            client.set("k", "v", Duration.ofSeconds(1));
+            assertEquals(List.of("k"), nodeA.setKeys);
+            assertEquals(List.of("k"), nodeB.setKeys);
+
+            nodeA.value = null;
+            nodeB.value = "v";
+            assertEquals("v", client.get("k"));
+
+            nodeA.deleteResult = false;
+            nodeB.deleteResult = true;
+            assertTrue(client.delete("k"));
+        }
+    }
+
+    private static final class RecordingNode implements Node<String, String> {
+        private final String id;
+        private final List<String> setKeys = new CopyOnWriteArrayList<>();
+        private volatile String value;
+        private volatile boolean deleteResult;
+
+        private RecordingNode(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public void set(String key, String value, Duration ttl) {
+            setKeys.add(key);
+            this.value = value;
+        }
+
+        @Override
+        public String get(String key) {
+            return value;
+        }
+
+        @Override
+        public boolean delete(String key) {
+            return deleteResult;
+        }
+
+        @Override
+        public String id() {
+            return id;
+        }
+    }
+}

--- a/src/test/java/com/can/cluster/ConsistentHashRingTest.java
+++ b/src/test/java/com/can/cluster/ConsistentHashRingTest.java
@@ -7,20 +7,28 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ConsistentHashRingTest {
 
     private static final HashFn SIMPLE_HASH = key -> Arrays.hashCode(key);
 
-    @Test
-    void returnsAvailableNodesWhenReplicationFactorExceedsUniqueNodes() {
-        ConsistentHashRing<String> ring = new ConsistentHashRing<>(SIMPLE_HASH, 3);
-        ring.addNode("node-1", "node-1".getBytes(StandardCharsets.UTF_8));
+    @Nested
+    class ReplicationRules {
+        /**
+         * Halka tek düğümlü olsa bile getReplicas isteğe yanıt verir; benzersiz düğümler döndürülür.
+         * Bu test replikasyon faktörü yüksek olduğunda bile aynı düğümün tekrar edilmediğini doğrular.
+         */
+        @Test
+        void returnsAvailableNodesWhenReplicationFactorExceedsUniqueNodes() {
+            ConsistentHashRing<String> ring = new ConsistentHashRing<>(SIMPLE_HASH, 3);
+            ring.addNode("node-1", "node-1".getBytes(StandardCharsets.UTF_8));
 
-        List<String> replicas = ring.getReplicas("key".getBytes(StandardCharsets.UTF_8), 5);
+            List<String> replicas = ring.getReplicas("key".getBytes(StandardCharsets.UTF_8), 5);
 
-        assertEquals(1, replicas.size(), "Only available nodes should be returned");
-        assertIterableEquals(List.of("node-1"), replicas);
+            assertEquals(1, replicas.size(), "Only available nodes should be returned");
+            assertIterableEquals(List.of("node-1"), replicas);
+        }
     }
 }

--- a/src/test/java/com/can/codec/CodecImplementationsTest.java
+++ b/src/test/java/com/can/codec/CodecImplementationsTest.java
@@ -1,0 +1,64 @@
+package com.can.codec;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Codec implementasyonları cache içerisinde veriyi byte dizisine çevirip geri döndürmek için kullanılır.
+ * Her bir codec'in null güvenliği ve doğru dönüşümü sağladığını detaylı açıklamalarla test ediyoruz.
+ */
+class CodecImplementationsTest {
+
+    @Nested
+    class StringCodecBehaviour {
+        /**
+         * StringCodec UTF-8 ile kodlar, null değerleri boş diziye çevirir.
+         * decode çağrısı boş diziyi yeniden null'a döndürerek orijinal anlamı korur.
+         */
+        @Test
+        void encodesAndDecodesUtf8Strings() {
+            byte[] encoded = StringCodec.UTF8.encode("merhaba");
+            assertArrayEquals("merhaba".getBytes(java.nio.charset.StandardCharsets.UTF_8), encoded);
+            assertEquals("merhaba", StringCodec.UTF8.decode(encoded));
+        }
+
+        @Test
+        void handlesNullValuesGracefully() {
+            assertArrayEquals(new byte[0], StringCodec.UTF8.encode(null));
+            assertNull(StringCodec.UTF8.decode(new byte[0]));
+        }
+    }
+
+    @Nested
+    class JavaSerializerCodecBehaviour {
+        /**
+         * JavaSerializerCodec standart Java serileştirmesini kullanır.
+         * encode-decode işlemi sırasında Serializable tiplerin durumu korunmalıdır.
+         */
+        @Test
+        void roundTripsSerializableObjects() {
+            JavaSerializerCodec<Dummy> codec = new JavaSerializerCodec<>();
+            Dummy original = new Dummy("key", 42);
+            byte[] bytes = codec.encode(original);
+            Dummy decoded = codec.decode(bytes);
+            assertEquals(original, decoded);
+        }
+
+        @Test
+        void nullValuesProduceEmptyArray() {
+            JavaSerializerCodec<String> codec = new JavaSerializerCodec<>();
+            assertArrayEquals(new byte[0], codec.encode(null));
+            assertNull(codec.decode(new byte[0]));
+        }
+    }
+
+    private record Dummy(String name, int value) implements Serializable {
+        @Serial
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/src/test/java/com/can/config/AppConfigRdbPathTest.java
+++ b/src/test/java/com/can/config/AppConfigRdbPathTest.java
@@ -1,6 +1,7 @@
 package com.can.config;
 
 import com.can.core.CacheEngine;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -15,23 +16,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AppConfigRdbPathTest {
 
-    @Test
-    void replaysDataFromCustomPath() throws IOException {
-        Path snapshotFile = Files.createTempFile("can-cache-test", ".rdb");
-        String key = Base64.getEncoder().encodeToString("foo".getBytes(StandardCharsets.UTF_8));
-        String value = Base64.getEncoder().encodeToString("bar".getBytes(StandardCharsets.UTF_8));
-        Files.writeString(snapshotFile, "S " + key + " " + value + " 0\n");
+    @Nested
+    class CustomSnapshotPath {
+        /**
+         * Konfigürasyonda verilen RDB yolu AppConfig tarafından SnapshotFile'e aktarılır.
+         * Test, dosyada bulunan Base64 kodlu girdinin uygulama açılışında CacheEngine'e yüklendiğini doğrular.
+         */
+        @Test
+        void replaysDataFromCustomPath() throws IOException {
+            Path snapshotFile = Files.createTempFile("can-cache-test", ".rdb");
+            String key = Base64.getEncoder().encodeToString("foo".getBytes(StandardCharsets.UTF_8));
+            String value = Base64.getEncoder().encodeToString("bar".getBytes(StandardCharsets.UTF_8));
+            Files.writeString(snapshotFile, "S " + key + " " + value + " 0\n");
 
-        try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext()) {
-            TestPropertyValues.of(
-                    "app.rdb.path=" + snapshotFile,
-                    "app.rdb.snapshot-interval-seconds=3600"
-            ).applyTo(ctx);
-            ctx.register(AppConfig.class);
-            ctx.refresh();
+            try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext()) {
+                TestPropertyValues.of(
+                        "app.rdb.path=" + snapshotFile,
+                        "app.rdb.snapshot-interval-seconds=3600"
+                ).applyTo(ctx);
+                ctx.register(AppConfig.class);
+                ctx.refresh();
 
-            CacheEngine<String, String> engine = ctx.getBean(CacheEngine.class);
-            assertEquals("bar", engine.get("foo"));
+                CacheEngine<String, String> engine = ctx.getBean(CacheEngine.class);
+                assertEquals("bar", engine.get("foo"));
+            }
         }
     }
 }

--- a/src/test/java/com/can/core/CacheEngineBehaviourTest.java
+++ b/src/test/java/com/can/core/CacheEngineBehaviourTest.java
@@ -1,0 +1,225 @@
+package com.can.core;
+
+import com.can.codec.StringCodec;
+import com.can.metric.MetricsRegistry;
+import com.can.metric.Timer;
+import com.can.pubsub.Broker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Bu sınıf cache motorunun omurgasını test ederken her bir davranışın ardındaki tasarım amacını satır arası yorumlarda ayrıntılı anlatır.
+ * CacheEngine veriyi segmentler üzerinde tutar, TTL kuyruğu ile siler, metrik ve pub/sub entegrasyonları sağlar.
+ */
+class CacheEngineBehaviourTest {
+
+    private CacheEngine<String, String> engine;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (engine != null) {
+            engine.close();
+            engine = null;
+        }
+    }
+
+    @Nested
+    class BasicUsage {
+        /**
+         * CacheEngine#set anahtar-değer çiftlerini segmentlenmiş tablolarda saklar.
+         * Her segment eşzamanlı erişim için kilitlenmiş LinkedHashMap kullanır, bu nedenle temel set/get akışını doğrularız.
+         */
+        @Test
+        void storesAndRetrievesValues() {
+            engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(2)
+                    .maxCapacity(16)
+                    .build();
+
+            engine.set("k", "v");
+
+            // get çağrısı veriyi codec ile çözerek döndürür; yoksa null verir.
+            assertEquals("v", engine.get("k"));
+            assertTrue(engine.exists("k"), "exists metodu TTL süresi dolmamış girdiler için true dönmeli");
+            assertEquals(1, engine.size(), "size tüm segmentlerdeki toplam girdi sayısını verir");
+        }
+
+        /**
+         * Silme işlemi segmentte kayıt olup olmadığına göre true/false döner ve TTL kuyruğundaki kayıtlar da temizlenmiş sayılır.
+         */
+        @Test
+        void deleteRemovesEntryAndSignalsResult() {
+            engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1)
+                    .maxCapacity(4)
+                    .build();
+
+            engine.set("foo", "bar");
+            assertTrue(engine.delete("foo"), "Var olan anahtar silindiğinde true dönmeli");
+            assertFalse(engine.delete("foo"), "Yok olan anahtar silinirken false dönmeli");
+            assertNull(engine.get("foo"));
+        }
+    }
+
+    @Nested
+    class TtlMechanics {
+        /**
+         * TTL verilen değerler ExpiringKey ile DelayQueue'ya yazılır, scheduled temizleyici poll ederek segmentten siler.
+         * Küçük süreli TTL verip temizlenmesini bekleyerek mekanizmanın uçtan uca çalıştığını doğrularız.
+         */
+        @Test
+        void removesEntriesAfterTtlExpires() throws Exception {
+            engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1)
+                    .maxCapacity(4)
+                    .cleanerPollMillis(5)
+                    .build();
+
+            engine.set("temp", "data", Duration.ofMillis(50));
+            assertEquals("data", engine.get("temp"));
+
+            // Temizleyicinin çalışabilmesi için yeterince bekliyoruz.
+            Thread.sleep(200);
+
+            assertNull(engine.get("temp"), "Süre dolunca kayıt otomatik silinmeli");
+            assertFalse(engine.exists("temp"), "exists de TTL dolduktan sonra false dönmeli");
+        }
+
+        /**
+         * Expire olmuş bir kayıt get sırasında yakalanır ve delete çağrısıyla temizlenirken miss metriği artar.
+         * Bu davranış "gecikmeli temizleme" stratejisini doğrular.
+         */
+        @Test
+        void lazyGetCleansExpiredEntries() throws Exception {
+            MetricsRegistry metrics = new MetricsRegistry();
+            engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1)
+                    .maxCapacity(2)
+                    .cleanerPollMillis(5)
+                    .metrics(metrics)
+                    .build();
+
+            engine.set("lazy", "value", Duration.ofMillis(10));
+            Thread.sleep(100);
+
+            assertNull(engine.get("lazy"), "Geçen sürede TTL dolduğu için get null dönmeli");
+            assertEquals(1, metrics.counter("cache_misses").get(), "Expire olan kayıt miss olarak sayılmalı");
+        }
+    }
+
+    @Nested
+    class MetricsIntegration {
+        /**
+         * MetricsRegistry üzerinden alınan sayaç ve timer nesneleri CacheEngine içinde tutulur.
+         * İşlemler yapıldığında sayaçlar artmalı, timer örnekleri kayıt sayısı tutmalı.
+         */
+        @Test
+        void recordsCountersAndTimers() {
+            MetricsRegistry metrics = new MetricsRegistry();
+            engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1)
+                    .maxCapacity(8)
+                    .metrics(metrics)
+                    .build();
+
+            engine.set("m", "1");
+            engine.set("m", "2");
+            engine.get("m");
+            engine.delete("missing");
+            engine.delete("m");
+
+            assertEquals(1, metrics.counter("cache_hits").get(), "Başarılı get çağrıları hit sayacını artırır");
+            assertTrue(metrics.counter("cache_misses").get() >= 1, "Kaçırılan işlemler miss sayaçlarında görünmeli");
+
+            Timer.Sample getSample = metrics.timer("cache_get").snapshot();
+            assertTrue(getSample.count() >= 1, "get zamanlayıcısı en az bir ölçüm içermeli");
+            assertTrue(metrics.timer("cache_set").snapshot().count() >= 1);
+            assertTrue(metrics.timer("cache_del").snapshot().count() >= 1);
+        }
+    }
+
+    @Nested
+    class PubSubHooks {
+        /**
+         * Broker, keyspace olaylarını dinleyen abonelere publish eder.
+         * CacheEngine set/delete çağrılarından sonra broker.publish tetiklenmeli.
+         */
+        @Test
+        void notifiesBrokerOnMutations() throws Exception {
+            try (Broker broker = new Broker()) {
+                engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                        .segments(1)
+                        .maxCapacity(4)
+                        .broker(broker)
+                        .build();
+
+                CountDownLatch setLatch = new CountDownLatch(1);
+                CountDownLatch delLatch = new CountDownLatch(1);
+
+                try (AutoCloseable ignored1 = broker.subscribe("keyspace:set", payload -> setLatch.countDown());
+                     AutoCloseable ignored2 = broker.subscribe("keyspace:del", payload -> delLatch.countDown())) {
+
+                    engine.set("pub", "sub");
+                    assertTrue(setLatch.await(1, TimeUnit.SECONDS), "Set sonrası publish bekleniyor");
+
+                    engine.delete("pub");
+                    assertTrue(delLatch.await(1, TimeUnit.SECONDS), "Delete sonrası publish bekleniyor");
+                }
+            }
+        }
+    }
+
+    @Nested
+    class ReplayAndIteration {
+        /**
+         * Snapshot dosyasından gelen S (set) kayıtları replay metoduna verildiğinde applyReplayEntry çağrılır.
+         * Expire olmuş kayıtlar segmentten kaldırılır, temiz kayıtlar TTL kuyruğuna eklenir.
+         */
+        @Test
+        void replaysEntriesAndSkipsExpiredOnes() throws Exception {
+            engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1)
+                    .maxCapacity(8)
+                    .cleanerPollMillis(5)
+                    .build();
+
+            long future = System.currentTimeMillis() + 1_000;
+            engine.replay(new byte[]{'S'}, StringCodec.UTF8.encode("a"), StringCodec.UTF8.encode("1"), future);
+
+            long past = System.currentTimeMillis() - 1_000;
+            engine.replay(new byte[]{'S'}, StringCodec.UTF8.encode("b"), StringCodec.UTF8.encode("2"), past);
+
+            assertEquals("1", engine.get("a"));
+            assertNull(engine.get("b"), "Geçmiş tarihli kayıt yüklenmemeli");
+        }
+
+        /**
+         * forEachEntry TTL'i dolmamış kayıtları callback'e gönderir.
+         * Bu yöntem snapshot alırken kullanılan veri aktarım kanalını temsil ettiği için sonuç listesini kontrol ederiz.
+         */
+        @Test
+        void iteratesOnlyLiveEntries() {
+            engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1)
+                    .maxCapacity(8)
+                    .build();
+
+            engine.set("x", "1");
+            engine.set("y", "2", Duration.ofDays(1));
+
+            List<String> seen = new ArrayList<>();
+            engine.forEachEntry((key, value, expireAt) -> seen.add(StringCodec.UTF8.decode(value)));
+
+            assertEquals(List.of("1", "2"), seen);
+        }
+    }
+}

--- a/src/test/java/com/can/core/CacheEngineEvictionPolicyTest.java
+++ b/src/test/java/com/can/core/CacheEngineEvictionPolicyTest.java
@@ -1,40 +1,55 @@
 package com.can.core;
 
 import com.can.codec.StringCodec;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class CacheEngineEvictionPolicyTest
 {
-    @Test
-    void builderDefaultsToLru()
-    {
-        try (CacheEngine<String,String> engine = CacheEngine.<String,String>builder(StringCodec.UTF8, StringCodec.UTF8)
-                .segments(1).maxCapacity(2)
-                .build())
+    @Nested
+    class DefaultPolicy {
+        /**
+         * Builder hiçbir politika verilmezse LRU kullanır; kapasite dolduğunda en eski giriş çıkar.
+         * Bu test LRU davranışını doğrularken sıcak anahtarın sonradan silindiğini gözlemler.
+         */
+        @Test
+        void builderDefaultsToLru()
         {
-            engine.set("hot", "v");
-            engine.set("cold-0", "v");
-            engine.set("cold-1", "v");
-            assertNull(engine.get("hot"));
+            try (CacheEngine<String,String> engine = CacheEngine.<String,String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1).maxCapacity(2)
+                    .build())
+            {
+                engine.set("hot", "v");
+                engine.set("cold-0", "v");
+                engine.set("cold-1", "v");
+                assertNull(engine.get("hot"));
+            }
         }
     }
 
-    @Test
-    void tinyLfuSelectionRetainsHotKeys()
-    {
-        try (CacheEngine<String,String> engine = CacheEngine.<String,String>builder(StringCodec.UTF8, StringCodec.UTF8)
-                .segments(1).maxCapacity(2)
-                .evictionPolicy(EvictionPolicyType.TINY_LFU)
-                .build())
+    @Nested
+    class TinyLfuPolicy {
+        /**
+         * TinyLFU erişim sıklığına göre yeni adayları kabul eder; sıcak anahtar defalarca erişildiğinde korunmalıdır.
+         * Test yoğun erişimden sonra yeni anahtarlar geldiğinde sıcak anahtarın hala erişilebilir olduğunu gösterir.
+         */
+        @Test
+        void tinyLfuSelectionRetainsHotKeys()
         {
-            engine.set("hot", "v");
-            for (int i=0;i<128;i++) assertEquals("v", engine.get("hot"));
-            engine.set("cold-0", "v");
-            engine.set("cold-1", "v");
-            assertEquals("v", engine.get("hot"));
-            assertNull(engine.get("cold-1"));
+            try (CacheEngine<String,String> engine = CacheEngine.<String,String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1).maxCapacity(2)
+                    .evictionPolicy(EvictionPolicyType.TINY_LFU)
+                    .build())
+            {
+                engine.set("hot", "v");
+                for (int i=0;i<128;i++) assertEquals("v", engine.get("hot"));
+                engine.set("cold-0", "v");
+                engine.set("cold-1", "v");
+                assertEquals("v", engine.get("hot"));
+                assertNull(engine.get("cold-1"));
+            }
         }
     }
 }

--- a/src/test/java/com/can/core/CacheEngineReplayTest.java
+++ b/src/test/java/com/can/core/CacheEngineReplayTest.java
@@ -2,6 +2,7 @@ package com.can.core;
 
 import com.can.codec.StringCodec;
 import com.can.pubsub.Broker;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -10,33 +11,44 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CacheEngineReplayTest {
 
-    @Test
-    void replaySetSkipsSideEffects() throws Exception {
-        var codec = StringCodec.UTF8;
-        AtomicInteger published = new AtomicInteger();
-        try (Broker broker = new Broker();
-             AutoCloseable ignored = broker.subscribe("keyspace:set", payload -> published.incrementAndGet());
-             CacheEngine<String, String> engine = CacheEngine.<String, String>builder(codec, codec)
-                     .broker(broker)
-                     .build()) {
-            long expireAt = System.currentTimeMillis() + 5_000;
-            engine.replay(new byte[]{'S'}, codec.encode("foo"), codec.encode("bar"), expireAt);
-            assertEquals("bar", engine.get("foo"));
-            Thread.sleep(50);
-            assertEquals(0, published.get());
+    @Nested
+    class ReplayBehaviour {
+        /**
+         * replay sırasında Broker bildirimleri tetiklenmez; persistence katmanı yalnızca belleği günceller.
+         * Bu test publish sayacının artmadığını kontrol ederek yan etkisiz yüklemeyi doğrular.
+         */
+        @Test
+        void replaySetSkipsSideEffects() throws Exception {
+            var codec = StringCodec.UTF8;
+            AtomicInteger published = new AtomicInteger();
+            try (Broker broker = new Broker();
+                 AutoCloseable ignored = broker.subscribe("keyspace:set", payload -> published.incrementAndGet());
+                 CacheEngine<String, String> engine = CacheEngine.<String, String>builder(codec, codec)
+                         .broker(broker)
+                         .build()) {
+                long expireAt = System.currentTimeMillis() + 5_000;
+                engine.replay(new byte[]{'S'}, codec.encode("foo"), codec.encode("bar"), expireAt);
+                assertEquals("bar", engine.get("foo"));
+                Thread.sleep(50);
+                assertEquals(0, published.get());
+            }
         }
-    }
 
-    @Test
-    void replaySkipsExpiredEntriesAndRemovesExistingValue() throws Exception {
-        var codec = StringCodec.UTF8;
-        try (CacheEngine<String, String> engine = CacheEngine.<String, String>builder(codec, codec).build()) {
-            engine.set("foo", "live");
-            long expiredAt = System.currentTimeMillis() - 1_000;
-            engine.replay(new byte[]{'S'}, codec.encode("foo"), codec.encode("stale"), expiredAt);
-            assertEquals(0, engine.size());
-            assertFalse(engine.exists("foo"));
-            assertNull(engine.get("foo"));
+        /**
+         * Expire olmuş kayıtlar replay sırasında atlanır ve var olan sıcak kayıtlar temizlenir.
+         * Böylece snapshot dosyasındaki bayat veriler cache'e geri yüklenmez.
+         */
+        @Test
+        void replaySkipsExpiredEntriesAndRemovesExistingValue() throws Exception {
+            var codec = StringCodec.UTF8;
+            try (CacheEngine<String, String> engine = CacheEngine.<String, String>builder(codec, codec).build()) {
+                engine.set("foo", "live");
+                long expiredAt = System.currentTimeMillis() - 1_000;
+                engine.replay(new byte[]{'S'}, codec.encode("foo"), codec.encode("stale"), expiredAt);
+                assertEquals(0, engine.size());
+                assertFalse(engine.exists("foo"));
+                assertNull(engine.get("foo"));
+            }
         }
     }
 }

--- a/src/test/java/com/can/core/CacheSegmentDetailedTest.java
+++ b/src/test/java/com/can/core/CacheSegmentDetailedTest.java
@@ -1,0 +1,155 @@
+package com.can.core;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * CacheSegment sınıfı segment bazlı veri tutar; kilitli LinkedHashMap kullanır ve EvictionPolicy ile bütünleşir.
+ * Aşağıdaki testler politikanın etkileşimi, zorunlu yazma ve snapshot davranışını detaylıca dokümante eder.
+ */
+class CacheSegmentDetailedTest {
+
+    private static CacheValue value(int marker) {
+        return new CacheValue(new byte[]{(byte) marker}, 0L);
+    }
+
+    @Nested
+    class PutOperations {
+        /**
+         * Politika yeni girişe izin vermezse CacheSegment put false döner ve mevcut veri korunur.
+         * Bu sayede TinyLFU gibi politikalar soğuk anahtarları engelleyebilir.
+         */
+        @Test
+        void rejectsInsertionWhenPolicyDisagrees() {
+            RecordingPolicy<String> policy = new RecordingPolicy<>();
+            CacheSegment<String> segment = new CacheSegment<>(1, policy);
+
+            policy.nextDecision(EvictionPolicy.AdmissionDecision.admit());
+            assertTrue(segment.put("hot", value(1)));
+
+            policy.nextDecision(EvictionPolicy.AdmissionDecision.reject());
+            assertFalse(segment.put("cold", value(2)), "Politika reddettiğinde segment yazmamalı");
+            assertNotNull(segment.get("hot"));
+            assertNull(segment.get("cold"));
+            assertEquals(2, policy.accessCount.get(), "Hem mevcut hem aday erişimler kaydedildi");
+        }
+
+        /**
+         * Politika bir kurban seçerse segment ilgili anahtarı map'ten çıkartıp yeni girdiyi ekler.
+         * onRemove çağrısı ile politika kendi iç istatistiklerini temizleyebilir.
+         */
+        @Test
+        void evictsVictimSelectedByPolicy() {
+            RecordingPolicy<String> policy = new RecordingPolicy<>();
+            CacheSegment<String> segment = new CacheSegment<>(1, policy);
+
+            policy.nextDecision(EvictionPolicy.AdmissionDecision.admit());
+            assertTrue(segment.put("hot", value(1)));
+
+            policy.nextDecision(EvictionPolicy.AdmissionDecision.admit("hot"));
+            assertTrue(segment.put("fresh", value(2)));
+            assertNull(segment.get("hot"), "Kurban kaldırılmış olmalı");
+            assertNotNull(segment.get("fresh"));
+            assertEquals(List.of("hot"), policy.removedKeys, "Politika onRemove ile haberdar edilir");
+        }
+    }
+
+    @Nested
+    class ForcedInsertions {
+        /**
+         * putForce kapasite dolu olsa bile sıradaki en eski girdiyi çıkarır; admission kontrolü yapılmaz.
+         * Snapshot yükleme gibi zorunlu durumlarda kullanılır, bu yüzden map boyutu korunurken veri yer değiştirir.
+         */
+        @Test
+        void putForceOverridesCapacity() {
+            RecordingPolicy<String> policy = new RecordingPolicy<>();
+            CacheSegment<String> segment = new CacheSegment<>(1, policy);
+
+            policy.nextDecision(EvictionPolicy.AdmissionDecision.admit());
+            segment.put("old", value(1));
+
+            assertTrue(segment.putForce("new", value(2)));
+            assertNull(segment.get("old"));
+            assertNotNull(segment.get("new"));
+            assertEquals(List.of("old"), policy.removedKeys, "Zorunlu kaldırmada da politika bilgilendirilir");
+        }
+
+        /**
+         * remove çağrısı var olan kaydı döndürür ve politikanın onRemove kancası tetiklenir.
+         * Bu mekanizma TTL temizleyicisi gibi bileşenler tarafından kullanılır.
+         */
+        @Test
+        void removeNotifiesPolicy() {
+            RecordingPolicy<String> policy = new RecordingPolicy<>();
+            CacheSegment<String> segment = new CacheSegment<>(4, policy);
+
+            policy.nextDecision(EvictionPolicy.AdmissionDecision.admit());
+            segment.put("sample", value(7));
+
+            assertNotNull(segment.remove("sample"));
+            assertNull(segment.get("sample"));
+            assertEquals(List.of("sample"), policy.removedKeys);
+        }
+    }
+
+    @Nested
+    class SnapshotView {
+        /**
+         * forEach metodu kilitli map'in kopyasını oluşturur ve dışarıya tutarlı bir anlık görüntü verir.
+         * Test sırasında callback içinden map değişse bile orijinal iterasyon bozulmamalı.
+         */
+        @Test
+        void forEachUsesSnapshotToAvoidConcurrentMutation() {
+            RecordingPolicy<String> policy = new RecordingPolicy<>();
+            CacheSegment<String> segment = new CacheSegment<>(4, policy);
+
+            policy.nextDecision(EvictionPolicy.AdmissionDecision.admit());
+            segment.put("a", value(1));
+            policy.nextDecision(EvictionPolicy.AdmissionDecision.admit());
+            segment.put("b", value(2));
+
+            List<String> seen = new ArrayList<>();
+            segment.forEach((key, value) -> {
+                seen.add(key + value.value[0]);
+                segment.remove(key);
+            });
+
+            assertEquals(List.of("a1", "b2"), seen, "Snapshot sayesinde iterasyon sırasında değişiklik sorun çıkarmaz");
+            assertEquals(0, segment.size(), "Callback sonrası removelar uygulanmış olmalı");
+        }
+    }
+
+    /** Basit kayıt tutan politika implementasyonu */
+    private static final class RecordingPolicy<K> implements EvictionPolicy<K> {
+        private final AtomicInteger accessCount = new AtomicInteger();
+        private final List<K> removedKeys = new ArrayList<>();
+        private AdmissionDecision<K> next = AdmissionDecision.admit();
+
+        void nextDecision(AdmissionDecision<K> decision) {
+            this.next = decision;
+        }
+
+        @Override
+        public void recordAccess(K key) {
+            accessCount.incrementAndGet();
+        }
+
+        @Override
+        public AdmissionDecision<K> admit(K key, java.util.LinkedHashMap<K, CacheValue> map, int capacity) {
+            AdmissionDecision<K> current = next;
+            next = AdmissionDecision.admit();
+            return current;
+        }
+
+        @Override
+        public void onRemove(K key) {
+            removedKeys.add(key);
+        }
+    }
+}

--- a/src/test/java/com/can/core/CacheSegmentEvictionPolicyTest.java
+++ b/src/test/java/com/can/core/CacheSegmentEvictionPolicyTest.java
@@ -1,32 +1,40 @@
 package com.can.core;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class CacheSegmentEvictionPolicyTest
 {
-    @Test
-    void tinyLfuRejectsColdKeysUnderSkew()
-    {
-        CacheSegment<String> lru = new CacheSegment<>(2, new LruEvictionPolicy<>());
-        CacheSegment<String> tiny = new CacheSegment<>(2, new TinyLfuEvictionPolicy<>(2));
-
-        assertTrue(lru.put("hot", value()));
-        assertTrue(tiny.put("hot", value()));
-        for (int i=0;i<128;i++) assertNotNull(tiny.get("hot"));
-
-        int lruAdmitted = 0, tinyAdmitted = 0;
-        for (int i=0;i<64;i++)
+    @Nested
+    class TinyLfuVsLru {
+        /**
+         * TinyLFU sıcak anahtarların sıklık istatistiğini tutar ve soğuk anahtar baskısı altında kurban seçiminde avantaj sağlar.
+         * Bu test binlerce erişim sonrasında aynı kapasitedeki LRU ile kıyaslayarak sıcak anahtarın TinyLFU'da hayatta kaldığını gösterir.
+         */
+        @Test
+        void tinyLfuRejectsColdKeysUnderSkew()
         {
-            String cold = "cold-" + i;
-            if (lru.put(cold, value())) lruAdmitted++;
-            if (tiny.put(cold, value())) tinyAdmitted++;
-        }
+            CacheSegment<String> lru = new CacheSegment<>(2, new LruEvictionPolicy<>());
+            CacheSegment<String> tiny = new CacheSegment<>(2, new TinyLfuEvictionPolicy<>(2));
 
-        assertTrue(lruAdmitted > tinyAdmitted, "TinyLFU should admit fewer cold keys");
-        assertNull(lru.get("hot"));
-        assertNotNull(tiny.get("hot"));
+            assertTrue(lru.put("hot", value()));
+            assertTrue(tiny.put("hot", value()));
+            for (int i=0;i<128;i++) assertNotNull(tiny.get("hot"));
+
+            int lruAdmitted = 0, tinyAdmitted = 0;
+            for (int i=0;i<64;i++)
+            {
+                String cold = "cold-" + i;
+                if (lru.put(cold, value())) lruAdmitted++;
+                if (tiny.put(cold, value())) tinyAdmitted++;
+            }
+
+            assertTrue(lruAdmitted > tinyAdmitted, "TinyLFU should admit fewer cold keys");
+            assertNull(lru.get("hot"));
+            assertNotNull(tiny.get("hot"));
+        }
     }
 
     private static CacheValue value(){ return new CacheValue(new byte[]{1}, 0L); }

--- a/src/test/java/com/can/core/CacheSupportTypesTest.java
+++ b/src/test/java/com/can/core/CacheSupportTypesTest.java
@@ -1,0 +1,80 @@
+package com.can.core;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Çekirdek paketindeki yardımcı tiplerin (CacheValue, ExpiringKey, EvictionPolicyType) davranışlarını belgeleyen testler.
+ * Bu tipler TTL ve politika seçimi gibi kritik kontrol noktalarının bel kemiğini oluşturur.
+ */
+class CacheSupportTypesTest {
+
+    @Nested
+    class CacheValueExpiry {
+        /**
+         * expired(now) metodu expireAtMillis değeri 0 veya geçmişteyse true/false döndürür.
+         * TTL'siz kayıtlar negatif veya sıfır değerde kalır ve hiçbir zaman expire olmaz.
+         */
+        @Test
+        void reportsExpiryStateCorrectly() {
+            CacheValue immortal = new CacheValue(new byte[]{1}, 0L);
+            assertFalse(immortal.expired(System.currentTimeMillis()), "TTL tanımlanmayan kayıt geçersiz sayılmamalı");
+
+            long past = System.currentTimeMillis() - 1_000;
+            CacheValue stale = new CacheValue(new byte[]{1}, past);
+            assertTrue(stale.expired(System.currentTimeMillis()), "Geçmiş zamanlı kayıt expire olmalı");
+
+            long future = System.currentTimeMillis() + 1_000;
+            CacheValue fresh = new CacheValue(new byte[]{1}, future);
+            assertFalse(fresh.expired(System.currentTimeMillis()), "Gelecekte expire olacak kayıt henüz geçerli");
+        }
+    }
+
+    @Nested
+    class ExpiringKeyOrdering {
+        /**
+         * DelayQueue içerisinde kullanılmak üzere getDelay dinamik bir süre döndürür.
+         * Süre azaldıkça değer de azalmalı, compareTo daha erken bitecek anahtarı öncelemelidir.
+         */
+        @Test
+        void delayReflectsRemainingTimeAndOrdering() throws InterruptedException {
+            long now = System.currentTimeMillis();
+            ExpiringKey near = new ExpiringKey("a", 0, now + 50);
+            ExpiringKey far = new ExpiringKey("b", 0, now + 200);
+
+            long nearDelay = near.getDelay(TimeUnit.MILLISECONDS);
+            assertTrue(nearDelay <= 60 && nearDelay > 0, "Yakın sürede bitecek anahtarın gecikmesi pozitif ve küçük olmalı");
+
+            Thread.sleep(40);
+            long reducedDelay = near.getDelay(TimeUnit.MILLISECONDS);
+            assertTrue(reducedDelay < nearDelay, "Zaman geçtikçe gecikme küçülmeli");
+
+            assertTrue(near.compareTo(far) < 0, "compareTo daha erken süresi dolacak anahtarı öncelemeli");
+        }
+    }
+
+    @Nested
+    class EvictionPolicyParsing {
+        /**
+         * fromConfig boş veya tanınmayan değerler geldiğinde varsayılan LRU'yu seçer.
+         * Ayrıca farklı yazım biçimlerini normalize ederek TinyLFU gibi seçenekleri döndürmelidir.
+         */
+        @Test
+        void parsesConfigValuesCaseInsensitive() {
+            assertEquals(EvictionPolicyType.LRU, EvictionPolicyType.fromConfig(null));
+            assertEquals(EvictionPolicyType.LRU, EvictionPolicyType.fromConfig("  "));
+            assertEquals(EvictionPolicyType.TINY_LFU, EvictionPolicyType.fromConfig("tiny-lfu"));
+        }
+
+        @Test
+        void throwsOnUnknownPolicy() {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> EvictionPolicyType.fromConfig("unknown"));
+            assertTrue(ex.getMessage().contains("Unknown eviction policy"));
+        }
+    }
+}

--- a/src/test/java/com/can/metric/MetricsComponentsTest.java
+++ b/src/test/java/com/can/metric/MetricsComponentsTest.java
@@ -1,0 +1,100 @@
+package com.can.metric;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Sayaç, zamanlayıcı ve raporlama bileşenleri cache motorunun gözlemlenebilirliğini sağlar.
+ * Testlerde hem içsel istatistiklerin hem de raporlamanın beklenen şekilde çalıştığını yorumlarla belgeliyoruz.
+ */
+class MetricsComponentsTest {
+
+    private MetricsReporter reporter;
+    private PrintStream originalOut;
+
+    @AfterEach
+    void cleanup() {
+        if (reporter != null) {
+            reporter.close();
+            reporter = null;
+        }
+        if (originalOut != null) {
+            System.setOut(originalOut);
+            originalOut = null;
+        }
+    }
+
+    @Nested
+    class CounterBehaviour {
+        /**
+         * Counter atomik sayaç kullanarak artışları toplar.
+         * inc ve add çağrılarının toplamı get ile okunabilmeli.
+         */
+        @Test
+        void accumulatesIncrements() {
+            Counter counter = new Counter("hits");
+            counter.inc();
+            counter.add(4);
+            assertEquals(5, counter.get());
+            assertEquals("hits", counter.name());
+        }
+    }
+
+    @Nested
+    class TimerBehaviour {
+        /**
+         * Timer kayıtları ring-buffer tarzı reservoir'e yazar, snapshot istatistik döndürür.
+         * Ortalama, min, max ve percentil değerlerinin beklenen aralıkta olduğunu kontrol ederiz.
+         */
+        @Test
+        void aggregatesSampleStatistics() {
+            Timer timer = new Timer("latency", 128);
+            timer.record(100);
+            timer.record(200);
+            timer.record(400);
+
+            Timer.Sample sample = timer.snapshot();
+            assertEquals("latency", sample.name());
+            assertEquals(3, sample.count());
+            assertEquals(700, sample.totalNs());
+            assertEquals(100, sample.minNs());
+            assertEquals(400, sample.maxNs());
+            assertTrue(sample.avgNs() >= 200 && sample.avgNs() <= 300);
+            assertTrue(sample.p95Ns() >= sample.p50Ns(), "p95 her zaman p50'den büyük ya da eşit olmalı");
+        }
+    }
+
+    @Nested
+    class RegistryAndReporterBehaviour {
+        /**
+         * MetricsRegistry sayaç/zamanlayıcı örneklerini tekil tutar.
+         * MetricsReporter start edildiğinde belirli aralıklarla System.out'a rapor yazar; çıktıyı yakalayıp doğrularız.
+         */
+        @Test
+        void reportsRegisteredMetricsPeriodically() throws InterruptedException {
+            MetricsRegistry registry = new MetricsRegistry();
+            registry.counter("c").add(2);
+            registry.timer("t").record(1_000_000);
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            originalOut = System.out;
+            System.setOut(new PrintStream(baos));
+
+            reporter = new MetricsReporter(registry);
+            reporter.start(1);
+
+            Thread.sleep(1_200); // en az bir dump çağrısı gerçekleşsin
+
+            String output = baos.toString();
+            assertTrue(output.contains("=== metrics ==="));
+            assertTrue(output.contains("counter c = 2"));
+            assertTrue(output.contains("timer t"));
+        }
+    }
+}

--- a/src/test/java/com/can/pubsub/BrokerAndStreamLogTest.java
+++ b/src/test/java/com/can/pubsub/BrokerAndStreamLogTest.java
@@ -1,0 +1,66 @@
+package com.can.pubsub;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pub/Sub alt sistemi cache motorundaki olayları dinlemeyi sağlar, StreamLog ise basit bir kalıcı kayıt kuyruğudur.
+ * Testler asenkron yayın, abonelikten çıkma ve log'un dairesel davranışını açıklar.
+ */
+class BrokerAndStreamLogTest {
+
+    @Nested
+    class BrokerBehaviour {
+        /**
+         * Broker her publish çağrısında kayıtlı aboneleri sanal thread üzerinde çalıştırır.
+         * CountDownLatch ile asenkron çağrının gerçekleştiğini doğrular, AutoCloseable ile abonelikten çıkmayı deneriz.
+         */
+        @Test
+        void deliversPayloadsToSubscribers() throws Exception {
+            try (Broker broker = new Broker()) {
+                CountDownLatch latch = new CountDownLatch(1);
+                AutoCloseable subscription = broker.subscribe("topic", payload -> {
+                    assertArrayEquals("selam".getBytes(StandardCharsets.UTF_8), payload);
+                    latch.countDown();
+                });
+
+                broker.publish("topic", "selam".getBytes(StandardCharsets.UTF_8));
+                assertTrue(latch.await(1, TimeUnit.SECONDS), "Asenkron mesaj abonelere ulaşmalı");
+
+                subscription.close();
+                CountDownLatch second = new CountDownLatch(1);
+                AutoCloseable secondSub = broker.subscribe("topic", payload -> second.countDown());
+                broker.publish("topic", new byte[0]);
+                assertTrue(second.await(1, TimeUnit.SECONDS), "Yeni abonelik çalışmalı");
+                secondSub.close();
+            }
+        }
+    }
+
+    @Nested
+    class StreamLogBehaviour {
+        /**
+         * StreamLog maksimum kapasiteye ulaştığında en eski kayıtları silip yenilerine yer açar.
+         * xrange metodu FIFO sırasını koruyarak istenen sayıda kayıt döndürür.
+         */
+        @Test
+        void keepsSlidingWindowOfEntries() {
+            StreamLog log = new StreamLog(2);
+            log.xadd("bir".getBytes(StandardCharsets.UTF_8));
+            log.xadd("iki".getBytes(StandardCharsets.UTF_8));
+            log.xadd("uc".getBytes(StandardCharsets.UTF_8));
+
+            List<byte[]> lastTwo = log.xrange(5);
+            assertEquals(2, lastTwo.size());
+            assertArrayEquals("iki".getBytes(StandardCharsets.UTF_8), lastTwo.get(0));
+            assertArrayEquals("uc".getBytes(StandardCharsets.UTF_8), lastTwo.get(1));
+        }
+    }
+}

--- a/src/test/java/com/can/rdb/SnapshotComponentsTest.java
+++ b/src/test/java/com/can/rdb/SnapshotComponentsTest.java
@@ -1,0 +1,94 @@
+package com.can.rdb;
+
+import com.can.codec.StringCodec;
+import com.can.core.CacheEngine;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * SnapshotFile ve SnapshotScheduler cache durumunu diske yazarak kalıcılık sağlar.
+ * Testler yazma/okuma akışını ve zamanlanmış snapshot davranışını ayrıntılı biçimde açıklar.
+ */
+class SnapshotComponentsTest {
+
+    private CacheEngine<String, String> engine;
+    private SnapshotScheduler<String, String> scheduler;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (scheduler != null) {
+            scheduler.close();
+            scheduler = null;
+        }
+        if (engine != null) {
+            engine.close();
+            engine = null;
+        }
+    }
+
+    @Nested
+    class SnapshotFileBehaviour {
+        /**
+         * write metodu CacheEngine.forEachEntry üzerinden Base64 kodlu kayıtları temp dosyaya yazar.
+         * load çağrısı geçerli satırları okuyup CacheEngine.replay ile belleğe geri yükler, bozuk satırlar atlanır.
+         */
+        @Test
+        void writesAndLoadsCacheEntries() throws Exception {
+            File temp = File.createTempFile("can-cache", ".rdb");
+            SnapshotFile<String, String> snapshot = new SnapshotFile<>(temp, StringCodec.UTF8);
+
+            engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1)
+                    .maxCapacity(8)
+                    .build();
+            engine.set("alive", "1");
+            engine.set("ttl", "2", Duration.ofSeconds(1));
+            snapshot.write(engine);
+            engine.close();
+
+            CacheEngine<String, String> empty = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1)
+                    .maxCapacity(8)
+                    .build();
+
+            Files.writeString(temp.toPath(), Files.readString(temp.toPath()) + "\nM bozuk satir\n");
+
+            snapshot.load(empty);
+            assertEquals("1", empty.get("alive"));
+            assertEquals("2", empty.get("ttl"));
+            empty.close();
+        }
+    }
+
+    @Nested
+    class SnapshotSchedulerBehaviour {
+        /**
+         * Scheduler başlatıldığında önce hemen bir snapshot yazar, ardından belirlenen aralıklarla tekrarlar.
+         * Testte aralık 0 vererek yalnızca başlangıç snapshot'unun oluştuğunu doğrularız.
+         */
+        @Test
+        void triggersImmediateSnapshotOnStart() throws Exception {
+            File temp = File.createTempFile("can-cache", ".rdb");
+            SnapshotFile<String, String> snapshot = new SnapshotFile<>(temp, StringCodec.UTF8);
+            engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                    .segments(1)
+                    .maxCapacity(4)
+                    .build();
+            engine.set("key", "value");
+
+            scheduler = new SnapshotScheduler<>(engine, snapshot, 0);
+            scheduler.start();
+
+            Thread.sleep(200);
+
+            assertTrue(Files.size(temp.toPath()) > 0, "Başlangıç snapshot dosyaya yazılmalı");
+        }
+    }
+}

--- a/src/test/java/com/can/scripting/ScriptingComponentsTest.java
+++ b/src/test/java/com/can/scripting/ScriptingComponentsTest.java
@@ -1,0 +1,81 @@
+package com.can.scripting;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * ScriptEngineApi kayıtlı fonksiyonları cache operasyonlarıyla çalıştırır, ScriptRegistry ise isteğe bağlı JS motoru sağlar.
+ * Testler API'nin bağlamı nasıl kullandığını ve JS motorunun var/yok durumunu açıklayan yorumlarla birlikte sunar.
+ */
+class ScriptingComponentsTest {
+
+    @Nested
+    class ScriptEngineApiBehaviour {
+        /**
+         * register-run akışı fonksiyonu isimle eşleyip Context üzerinden cache işlemleri yaptırır.
+         * Burada basit bir toplama fonksiyonu tanımlayıp set/get/del kombinasyonunu doğruluyoruz.
+         */
+        @Test
+        void executesRegisteredFunctionsWithContext() {
+            ScriptEngineApi<String, String> api = new ScriptEngineApi<>();
+            AtomicReference<String> stored = new AtomicReference<>();
+            AtomicReference<Boolean> deleted = new AtomicReference<>(false);
+            ScriptEngineApi.Context.CacheOps<String, String> ops = new ScriptEngineApi.Context.CacheOps<>() {
+                @Override
+                public void set(String key, String value, Duration ttl) {
+                    stored.set(key + value + ttl.toMillis());
+                }
+
+                @Override
+                public String get(String key) {
+                    return stored.get();
+                }
+
+                @Override
+                public boolean del(String key) {
+                    deleted.set(true);
+                    return true;
+                }
+            };
+
+            api.register("demo", (ctx, args) -> {
+                ctx.cache().set("k", "v", Duration.ofSeconds(1));
+                String read = ctx.cache().get("k");
+                ctx.cache().del("k");
+                return read;
+            });
+
+            Object result = api.run("demo", new ScriptEngineApi.Context<>(ops));
+            assertEquals("kv1000", stored.get());
+            assertEquals("kv1000", result);
+            assertTrue(deleted.get());
+        }
+    }
+
+    @Nested
+    class ScriptRegistryBehaviour {
+        /**
+         * ScriptRegistry JVM'de JavaScript motoru varsa jsAvailable true döndürür ve kod çalıştırabilir.
+         * Motor yoksa IllegalStateException fırlatır; her iki durum da kontrollü şekilde ele alınır.
+         */
+        @Test
+        void handlesOptionalJavaScriptEngine() {
+            ScriptRegistry registry = new ScriptRegistry();
+            if (registry.jsAvailable()) {
+                Map<String, Object> bindings = new HashMap<>();
+                bindings.put("x", 2);
+                Object value = registry.runJs("x + 3", bindings);
+                assertEquals(5.0, value);
+            } else {
+                assertThrows(IllegalStateException.class, () -> registry.runJs("1+1", Map.of()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add detailed, comment-rich unit suites for CacheEngine covering TTL cleanup, metrics, pub/sub and replay flows
- introduce nested test groups for codecs, metrics, clustering, persistence, pub/sub and scripting helpers to document behaviour end-to-end
- refresh existing tests to follow the documented @Nested structure and explanations for configuration and eviction policies

## Testing
- `mvn test` *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0277174f48323aca48f17ea5c2baf