### PR TITLE
Use Quarkus profile for RDB path test

### DIFF
--- a/src/test/java/com/can/config/AppConfigRdbPathTest.java
+++ b/src/test/java/com/can/config/AppConfigRdbPathTest.java
@@ -1,20 +1,34 @@
 package com.can.config;
 
 import com.can.core.CacheEngine;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@QuarkusTest
+@TestProfile(AppConfigRdbPathTest.CustomSnapshotProfile.class)
 class AppConfigRdbPathTest {
+
+    @Inject
+    CacheEngine<String, String> engine;
+
+    @AfterAll
+    static void cleanup() throws IOException {
+        Files.deleteIfExists(CustomSnapshotProfile.SNAPSHOT_FILE);
+    }
 
     @Nested
     class CustomSnapshotPath {
@@ -23,23 +37,32 @@ class AppConfigRdbPathTest {
          * Test, dosyada bulunan Base64 kodlu girdinin uygulama açılışında CacheEngine'e yüklendiğini doğrular.
          */
         @Test
-        void replaysDataFromCustomPath() throws IOException {
-            Path snapshotFile = Files.createTempFile("can-cache-test", ".rdb");
-            String key = Base64.getEncoder().encodeToString("foo".getBytes(StandardCharsets.UTF_8));
-            String value = Base64.getEncoder().encodeToString("bar".getBytes(StandardCharsets.UTF_8));
-            Files.writeString(snapshotFile, "S " + key + " " + value + " 0\n");
+        void replaysDataFromCustomPath() {
+            assertEquals("bar", engine.get("foo"));
+        }
+    }
 
-            try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext()) {
-                TestPropertyValues.of(
-                        "app.rdb.path=" + snapshotFile,
-                        "app.rdb.snapshot-interval-seconds=3600"
-                ).applyTo(ctx);
-                ctx.register(AppConfig.class);
-                ctx.refresh();
+    static class CustomSnapshotProfile implements QuarkusTestProfile {
 
-                CacheEngine<String, String> engine = ctx.getBean(CacheEngine.class);
-                assertEquals("bar", engine.get("foo"));
+        static final Path SNAPSHOT_FILE;
+        private static final String KEY = Base64.getEncoder().encodeToString("foo".getBytes(StandardCharsets.UTF_8));
+        private static final String VALUE = Base64.getEncoder().encodeToString("bar".getBytes(StandardCharsets.UTF_8));
+
+        static {
+            try {
+                SNAPSHOT_FILE = Files.createTempFile("can-cache-test", ".rdb");
+                Files.writeString(SNAPSHOT_FILE, "S " + KEY + " " + VALUE + " 0\n");
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to initialize snapshot file", e);
             }
+        }
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "app.rdb.path", SNAPSHOT_FILE.toString(),
+                    "app.rdb.snapshot-interval-seconds", "3600"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the Spring test context usage with a Quarkus @TestProfile based setup
- preload the snapshot file before the Quarkus container boots and verify CacheEngine contents via CDI injection
- clean up the temporary snapshot file after the test run

## Testing
- `mvn test` *(fails: repository download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0301cf1c88323973b4803c1f3e414