### PR TITLE
Fix Quarkus test profile construction

### DIFF
--- a/src/test/java/com/can/config/AppConfigRdbPathTest.java
+++ b/src/test/java/com/can/config/AppConfigRdbPathTest.java
@@ -48,6 +48,9 @@ class AppConfigRdbPathTest {
         private static final String KEY = Base64.getEncoder().encodeToString("foo".getBytes(StandardCharsets.UTF_8));
         private static final String VALUE = Base64.getEncoder().encodeToString("bar".getBytes(StandardCharsets.UTF_8));
 
+        public CustomSnapshotProfile() {
+        }
+
         static {
             try {
                 SNAPSHOT_FILE = Files.createTempFile("can-cache-test", ".rdb");


### PR DESCRIPTION
## Summary
- add an explicit public no-args constructor to `CustomSnapshotProfile` so Quarkus can instantiate it during test discovery

## Testing
- `./mvnw -Dtest=AppConfigRdbPathTest test` *(fails: wget could not download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d032b745dc832394805e76a2ba1ba5