### PR TITLE
Fix Quarkus test profile accessibility

### DIFF
--- a/src/test/java/com/can/config/AppConfigRdbPathTest.java
+++ b/src/test/java/com/can/config/AppConfigRdbPathTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 @TestProfile(AppConfigRdbPathTest.CustomSnapshotProfile.class)
-class AppConfigRdbPathTest {
+public class AppConfigRdbPathTest {
 
     @Inject
     CacheEngine<String, String> engine;
@@ -42,7 +42,7 @@ class AppConfigRdbPathTest {
         }
     }
 
-    static class CustomSnapshotProfile implements QuarkusTestProfile {
+    public static class CustomSnapshotProfile implements QuarkusTestProfile {
 
         static final Path SNAPSHOT_FILE;
         private static final String KEY = Base64.getEncoder().encodeToString("foo".getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
## Summary
- make `AppConfigRdbPathTest` public so Quarkus can load its profile
- expose `CustomSnapshotProfile` as public to allow Quarkus test infrastructure to instantiate it

## Testing
- mvn test *(fails: unable to resolve Maven artifacts because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d03378b4388323ba0b122d13257e9e