### PR TITLE
Add multicast coordination and replication support

### DIFF
--- a/src/main/java/com/can/cluster/coordination/CoordinationService.java
+++ b/src/main/java/com/can/cluster/coordination/CoordinationService.java
@@ -1,0 +1,300 @@
+package com.can.cluster.coordination;
+
+import com.can.cluster.ConsistentHashRing;
+import com.can.cluster.Node;
+import com.can.config.AppProperties;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MulticastSocket;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Multicast tabanlı hafif bir koordinasyon katmanı. Her düğüm belirli aralıklarla
+ * kümedeki varlığını duyurur, gelen duyuruları dinleyerek {@link ConsistentHashRing}
+ * üzerinde temsil ettiği düğümleri ekler veya çıkarır. Böylece yeni can-cache
+ * örnekleri ayağa kalktığında diğer JVM'ler tarafından otomatik olarak keşfedilir
+ * ve RAM'deki veriler replikasyon protokolü aracılığıyla senkronize edilir.
+ */
+@Singleton
+public class CoordinationService implements AutoCloseable
+{
+    private static final Logger LOG = Logger.getLogger(CoordinationService.class);
+    private static final int MAX_PACKET_SIZE = 1024;
+
+    private final ConsistentHashRing<Node<String, String>> ring;
+    private final Node<String, String> localNode;
+    private final AppProperties.Cluster.Discovery discoveryConfig;
+    private final AppProperties.Cluster.Replication replicationConfig;
+
+    private final Map<String, RemoteMember> members = new ConcurrentHashMap<>();
+    private final Object membershipLock = new Object();
+
+    private MulticastSocket listenSocket;
+    private DatagramSocket sendSocket;
+    private InetAddress groupAddress;
+    private ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> heartbeatTask;
+    private ScheduledFuture<?> reapTask;
+    private Thread listenerThread;
+    private volatile boolean running;
+
+    @Inject
+    public CoordinationService(ConsistentHashRing<Node<String, String>> ring,
+                               Node<String, String> localNode,
+                               AppProperties properties) {
+        this.ring = ring;
+        this.localNode = localNode;
+        var cluster = properties.cluster();
+        this.discoveryConfig = cluster.discovery();
+        this.replicationConfig = cluster.replication();
+    }
+
+    @PostConstruct
+    void start() {
+        try {
+            setupSockets();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to initialise coordination sockets", e);
+        }
+
+        ring.addNode(localNode, localNode.id().getBytes(StandardCharsets.UTF_8));
+        running = true;
+
+        listenerThread = new Thread(this::listenLoop, "coordination-listener");
+        listenerThread.setDaemon(true);
+        listenerThread.start();
+
+        scheduler = Executors.newScheduledThreadPool(1, Thread.ofVirtual().factory());
+        long heartbeat = Math.max(1000L, discoveryConfig.heartbeatIntervalMillis());
+        long reapInterval = Math.max(heartbeat, discoveryConfig.failureTimeoutMillis() / 2);
+        heartbeatTask = scheduler.scheduleAtFixedRate(this::broadcastHeartbeat, 0L, heartbeat, TimeUnit.MILLISECONDS);
+        reapTask = scheduler.scheduleAtFixedRate(this::pruneDeadMembers, reapInterval, reapInterval, TimeUnit.MILLISECONDS);
+
+        LOG.infof("Coordination service started for node %s, announcing %s:%d", localNode.id(),
+                advertisedHost(), replicationConfig.port());
+    }
+
+    private void setupSockets() throws IOException {
+        groupAddress = InetAddress.getByName(discoveryConfig.multicastGroup());
+        listenSocket = new MulticastSocket(discoveryConfig.multicastPort());
+        listenSocket.setReuseAddress(true);
+        NetworkInterface networkInterface = selectInterface();
+        listenSocket.joinGroup(new InetSocketAddress(groupAddress, discoveryConfig.multicastPort()), networkInterface);
+        sendSocket = new DatagramSocket();
+        sendSocket.setReuseAddress(true);
+    }
+
+    private NetworkInterface selectInterface() throws SocketException {
+        // Önce bind host'u deneyelim, değilse multicast destekleyen ilk arayüzü seçelim.
+        try {
+            InetAddress bindAddress = InetAddress.getByName(replicationConfig.bindHost());
+            NetworkInterface ni = NetworkInterface.getByInetAddress(bindAddress);
+            if (ni != null && ni.isUp() && ni.supportsMulticast()) {
+                return ni;
+            }
+        } catch (IOException ignored) {
+        }
+
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface ni = interfaces.nextElement();
+            if (ni.isUp() && ni.supportsMulticast() && !ni.isLoopback()) {
+                return ni;
+            }
+        }
+        NetworkInterface loopback = NetworkInterface.getByInetAddress(InetAddress.getLoopbackAddress());
+        if (loopback != null) {
+            return loopback;
+        }
+        throw new SocketException("No multicast-capable network interface found");
+    }
+
+    private void listenLoop() {
+        byte[] buffer = new byte[MAX_PACKET_SIZE];
+        while (running) {
+            DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+            try {
+                listenSocket.receive(packet);
+                handlePacket(packet.getData(), packet.getLength());
+            } catch (IOException e) {
+                if (running) {
+                    LOG.warn("Failed to receive coordination packet", e);
+                }
+            }
+        }
+    }
+
+    private void handlePacket(byte[] data, int length) {
+        String message = new String(data, 0, length, StandardCharsets.UTF_8);
+        String[] parts = message.split("\\|");
+        if (parts.length != 4 || !Objects.equals(parts[0], "HELLO")) {
+            return;
+        }
+
+        String nodeId = parts[1];
+        if (nodeId.equals(localNode.id())) {
+            return;
+        }
+
+        String host = parts[2];
+        int port;
+        try {
+            port = Integer.parseInt(parts[3]);
+        } catch (NumberFormatException e) {
+            LOG.debugf("Ignoring coordination packet with invalid port: %s", message);
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        byte[] idBytes = nodeId.getBytes(StandardCharsets.UTF_8);
+
+        synchronized (membershipLock) {
+            RemoteMember existing = members.get(nodeId);
+            if (existing == null) {
+                RemoteNode remoteNode = new RemoteNode(nodeId, host, port, replicationConfig.connectTimeoutMillis());
+                members.put(nodeId, new RemoteMember(remoteNode, idBytes, host, port, now));
+                ring.addNode(remoteNode, idBytes);
+                LOG.infof("Discovered new cluster member %s at %s:%d", nodeId, host, port);
+            } else if (!existing.matches(host, port)) {
+                ring.removeNode(existing.node(), existing.idBytes());
+                RemoteNode remoteNode = new RemoteNode(nodeId, host, port, replicationConfig.connectTimeoutMillis());
+                members.put(nodeId, new RemoteMember(remoteNode, idBytes, host, port, now));
+                ring.addNode(remoteNode, idBytes);
+                LOG.infof("Cluster member %s moved to %s:%d", nodeId, host, port);
+            } else {
+                existing.updateLastSeen(now);
+            }
+        }
+    }
+
+    private void broadcastHeartbeat() {
+        String payload = String.format("HELLO|%s|%s|%d", localNode.id(), advertisedHost(), replicationConfig.port());
+        byte[] bytes = payload.getBytes(StandardCharsets.UTF_8);
+        DatagramPacket packet = new DatagramPacket(bytes, bytes.length, groupAddress, discoveryConfig.multicastPort());
+        try {
+            sendSocket.send(packet);
+        } catch (IOException e) {
+            LOG.warn("Failed to send coordination heartbeat", e);
+        }
+    }
+
+    private void pruneDeadMembers() {
+        long now = System.currentTimeMillis();
+        long timeout = Math.max(discoveryConfig.failureTimeoutMillis(), discoveryConfig.heartbeatIntervalMillis() * 3);
+
+        synchronized (membershipLock) {
+            members.entrySet().removeIf(entry -> {
+                RemoteMember member = entry.getValue();
+                if (now - member.lastSeen() > timeout) {
+                    ring.removeNode(member.node(), member.idBytes());
+                    LOG.warnf("Cluster member %s (%s:%d) timed out", entry.getKey(), member.host(), member.port());
+                    return true;
+                }
+                return false;
+            });
+        }
+    }
+
+    private String advertisedHost() {
+        String host = replicationConfig.advertiseHost();
+        if (host == null || host.isBlank() || Objects.equals(host, "0.0.0.0")) {
+            return InetAddress.getLoopbackAddress().getHostAddress();
+        }
+        return host;
+    }
+
+    @PreDestroy
+    @Override
+    public void close() {
+        running = false;
+        if (heartbeatTask != null) {
+            heartbeatTask.cancel(true);
+        }
+        if (reapTask != null) {
+            reapTask.cancel(true);
+        }
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+        if (listenSocket != null) {
+            try {
+                listenSocket.close();
+            } catch (Exception ignored) {
+            }
+        }
+        if (sendSocket != null) {
+            sendSocket.close();
+        }
+        if (listenerThread != null) {
+            listenerThread.interrupt();
+        }
+
+        synchronized (membershipLock) {
+            members.values().forEach(member -> ring.removeNode(member.node(), member.idBytes()));
+            members.clear();
+        }
+    }
+
+    private static final class RemoteMember {
+        private final RemoteNode node;
+        private final byte[] idBytes;
+        private final String host;
+        private final int port;
+        private volatile long lastSeen;
+
+        private RemoteMember(RemoteNode node, byte[] idBytes, String host, int port, long lastSeen) {
+            this.node = node;
+            this.idBytes = idBytes;
+            this.host = host;
+            this.port = port;
+            this.lastSeen = lastSeen;
+        }
+
+        private RemoteNode node() {
+            return node;
+        }
+
+        private byte[] idBytes() {
+            return idBytes;
+        }
+
+        private String host() {
+            return host;
+        }
+
+        private int port() {
+            return port;
+        }
+
+        private long lastSeen() {
+            return lastSeen;
+        }
+
+        private void updateLastSeen(long value) {
+            this.lastSeen = value;
+        }
+
+        private boolean matches(String host, int port) {
+            return Objects.equals(this.host, host) && this.port == port;
+        }
+    }
+}

--- a/src/main/java/com/can/cluster/coordination/RemoteNode.java
+++ b/src/main/java/com/can/cluster/coordination/RemoteNode.java
@@ -1,0 +1,152 @@
+package com.can.cluster.coordination;
+
+import com.can.cluster.Node;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/**
+ * Bir başka can-cache örneğinin replikasyon sunucusuna TCP üzerinden bağlanarak
+ * {@link Node} sözleşmesini uygulayan hafif bir vekil düğümdür. Yazma işlemleri
+ * hedef düğümün bellek motoruna doğrudan iletilir, okuma ve silme çağrıları ise
+ * aynı protokol üzerinden yanıtlanır. Her çağrı için kısa ömürlü bir soket
+ * açıldığı için istemciler arasında durum paylaşımı yapılmaz ve başarısız
+ * bağlantılar yukarıya istisna olarak fırlatılır.
+ */
+public final class RemoteNode implements Node<String, String>
+{
+    private static final byte CMD_SET = 'S';
+    private static final byte CMD_GET = 'G';
+    private static final byte CMD_DELETE = 'D';
+    private static final byte RESP_OK = 'O';
+    private static final byte RESP_HIT = 'H';
+    private static final byte RESP_MISS = 'M';
+    private static final byte RESP_TRUE = 'T';
+    private static final byte RESP_FALSE = 'F';
+
+    private final String id;
+    private final InetSocketAddress address;
+    private final int connectTimeoutMillis;
+
+    public RemoteNode(String id, String host, int port, int connectTimeoutMillis) {
+        this.id = id;
+        this.address = new InetSocketAddress(host, port);
+        this.connectTimeoutMillis = Math.max(100, connectTimeoutMillis);
+    }
+
+    @Override
+    public void set(String key, String value, Duration ttl) {
+        long expireAt = ttl == null || ttl.isZero() || ttl.isNegative()
+                ? 0L
+                : System.currentTimeMillis() + ttl.toMillis();
+
+        byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+        byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
+
+        execute(socket -> {
+            DataOutputStream out = new DataOutputStream(new BufferedOutputStream(socket.getOutputStream()));
+            out.writeByte(CMD_SET);
+            out.writeInt(keyBytes.length);
+            out.writeInt(valueBytes.length);
+            out.writeLong(expireAt);
+            out.write(keyBytes);
+            out.write(valueBytes);
+            out.flush();
+
+            DataInputStream in = new DataInputStream(new BufferedInputStream(socket.getInputStream()));
+            byte response = in.readByte();
+            if (response != RESP_OK) {
+                throw new IOException("unexpected response to set: " + (char) response);
+            }
+        });
+    }
+
+    @Override
+    public String get(String key) {
+        byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+        return execute(socket -> {
+            DataOutputStream out = new DataOutputStream(new BufferedOutputStream(socket.getOutputStream()));
+            out.writeByte(CMD_GET);
+            out.writeInt(keyBytes.length);
+            out.write(keyBytes);
+            out.flush();
+
+            DataInputStream in = new DataInputStream(new BufferedInputStream(socket.getInputStream()));
+            byte response = in.readByte();
+            if (response == RESP_MISS) {
+                return null;
+            }
+            if (response != RESP_HIT) {
+                throw new IOException("unexpected response to get: " + (char) response);
+            }
+            int valueLength = in.readInt();
+            byte[] valueBytes = in.readNBytes(valueLength);
+            if (valueBytes.length != valueLength) {
+                throw new EOFException("incomplete value payload");
+            }
+            return new String(valueBytes, StandardCharsets.UTF_8);
+        });
+    }
+
+    @Override
+    public boolean delete(String key) {
+        byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+        return execute(socket -> {
+            DataOutputStream out = new DataOutputStream(new BufferedOutputStream(socket.getOutputStream()));
+            out.writeByte(CMD_DELETE);
+            out.writeInt(keyBytes.length);
+            out.write(keyBytes);
+            out.flush();
+
+            DataInputStream in = new DataInputStream(new BufferedInputStream(socket.getInputStream()));
+            byte response = in.readByte();
+            if (response == RESP_TRUE) {
+                return true;
+            }
+            if (response == RESP_FALSE) {
+                return false;
+            }
+            throw new IOException("unexpected response to delete: " + (char) response);
+        });
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    private <T> T execute(RemoteCall<T> call) {
+        try (Socket socket = new Socket()) {
+            socket.connect(address, connectTimeoutMillis);
+            socket.setTcpNoDelay(true);
+            return call.execute(socket);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to communicate with node " + id + " at " + address, e);
+        }
+    }
+
+    private void execute(RemoteCallWithoutResult call) {
+        execute(socket -> {
+            call.execute(socket);
+            return null;
+        });
+    }
+
+    @FunctionalInterface
+    private interface RemoteCall<T> {
+        T execute(Socket socket) throws IOException;
+    }
+
+    @FunctionalInterface
+    private interface RemoteCallWithoutResult {
+        void execute(Socket socket) throws IOException;
+    }
+}

--- a/src/main/java/com/can/cluster/coordination/ReplicationServer.java
+++ b/src/main/java/com/can/cluster/coordination/ReplicationServer.java
@@ -1,0 +1,199 @@
+package com.can.cluster.coordination;
+
+import com.can.config.AppProperties;
+import com.can.core.CacheEngine;
+import io.quarkus.runtime.Startup;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.jboss.logging.Logger;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Diğer düğümlerden gelen replikasyon komutlarını kabul ederek {@link CacheEngine}
+ * üzerinde doğrudan uygulayan hafif TCP sunucusudur. Protokol, {@link RemoteNode}
+ * tarafından kullanılan tek baytlık komutlardan oluşur ve bloklanmayı önlemek için
+ * istek başına sanal thread'lerle çalışır.
+ */
+@Singleton
+@Startup
+public class ReplicationServer implements AutoCloseable
+{
+    private static final Logger LOG = Logger.getLogger(ReplicationServer.class);
+
+    private final CacheEngine<String, String> engine;
+    private final AppProperties.Cluster.Replication config;
+
+    private volatile boolean running;
+    private ServerSocket serverSocket;
+    private ExecutorService workers;
+    private Thread acceptThread;
+
+    @Inject
+    public ReplicationServer(CacheEngine<String, String> engine, AppProperties properties) {
+        this.engine = engine;
+        this.config = properties.cluster().replication();
+    }
+
+    @PostConstruct
+    void start() {
+        workers = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory());
+        try {
+            serverSocket = new ServerSocket();
+            serverSocket.bind(new InetSocketAddress(config.bindHost(), config.port()));
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to bind replication port", e);
+        }
+
+        running = true;
+        acceptThread = new Thread(this::acceptLoop, "replication-acceptor");
+        acceptThread.setDaemon(true);
+        acceptThread.start();
+        LOG.infof("Replication server listening on %s:%d (advertised as %s:%d)",
+                config.bindHost(), serverSocket.getLocalPort(), config.advertiseHost(), config.port());
+    }
+
+    private void acceptLoop() {
+        while (running) {
+            try {
+                Socket socket = serverSocket.accept();
+                socket.setTcpNoDelay(true);
+                workers.execute(() -> handleClient(socket));
+            } catch (SocketException e) {
+                if (running) {
+                    LOG.warn("Replication server socket closed unexpectedly", e);
+                }
+                break;
+            } catch (IOException e) {
+                if (running) {
+                    LOG.error("Failed to accept replication client", e);
+                }
+            }
+        }
+    }
+
+    private void handleClient(Socket socket) {
+        try (socket;
+             DataInputStream in = new DataInputStream(new BufferedInputStream(socket.getInputStream()));
+             DataOutputStream out = new DataOutputStream(new BufferedOutputStream(socket.getOutputStream()))) {
+
+            while (running && !socket.isClosed()) {
+                byte command;
+                try {
+                    command = in.readByte();
+                } catch (EOFException eof) {
+                    break;
+                }
+
+                switch (command) {
+                    case 'S' -> handleSet(in, out);
+                    case 'G' -> handleGet(in, out);
+                    case 'D' -> handleDelete(in, out);
+                    default -> {
+                        LOG.warnf("Unknown replication command %d from %s", command & 0xff, socket.getRemoteSocketAddress());
+                        return;
+                    }
+                }
+            }
+        } catch (IOException e) {
+            LOG.debugf(e, "Replication client %s disconnected with error", socket.getRemoteSocketAddress());
+        }
+    }
+
+    private void handleSet(DataInputStream in, DataOutputStream out) throws IOException {
+        int keyLen = in.readInt();
+        int valueLen = in.readInt();
+        long expireAt = in.readLong();
+
+        byte[] keyBytes = in.readNBytes(keyLen);
+        byte[] valueBytes = in.readNBytes(valueLen);
+        if (keyBytes.length != keyLen || valueBytes.length != valueLen) {
+            throw new EOFException("Incomplete replication payload");
+        }
+
+        String key = new String(keyBytes, StandardCharsets.UTF_8);
+        String value = new String(valueBytes, StandardCharsets.UTF_8);
+        long now = System.currentTimeMillis();
+
+        if (expireAt <= 0L) {
+            engine.set(key, value);
+        } else if (expireAt <= now) {
+            engine.delete(key);
+        } else {
+            long ttlMillis = expireAt - now;
+            engine.set(key, value, Duration.ofMillis(ttlMillis));
+        }
+
+        out.writeByte('O');
+        out.flush();
+    }
+
+    private void handleGet(DataInputStream in, DataOutputStream out) throws IOException {
+        int keyLen = in.readInt();
+        byte[] keyBytes = in.readNBytes(keyLen);
+        if (keyBytes.length != keyLen) {
+            throw new EOFException("Incomplete get payload");
+        }
+
+        String key = new String(keyBytes, StandardCharsets.UTF_8);
+        String value = engine.get(key);
+
+        if (value == null) {
+            out.writeByte('M');
+            out.flush();
+            return;
+        }
+
+        byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
+        out.writeByte('H');
+        out.writeInt(valueBytes.length);
+        out.write(valueBytes);
+        out.flush();
+    }
+
+    private void handleDelete(DataInputStream in, DataOutputStream out) throws IOException {
+        int keyLen = in.readInt();
+        byte[] keyBytes = in.readNBytes(keyLen);
+        if (keyBytes.length != keyLen) {
+            throw new EOFException("Incomplete delete payload");
+        }
+
+        String key = new String(keyBytes, StandardCharsets.UTF_8);
+        boolean removed = engine.delete(key);
+        out.writeByte(removed ? 'T' : 'F');
+        out.flush();
+    }
+
+    @PreDestroy
+    @Override
+    public void close() {
+        running = false;
+        try {
+            if (serverSocket != null) {
+                serverSocket.close();
+            }
+        } catch (IOException ignored) {
+        }
+        if (acceptThread != null) {
+            acceptThread.interrupt();
+        }
+        if (workers != null) {
+            workers.shutdownNow();
+        }
+    }
+}

--- a/src/main/java/com/can/config/AppProperties.java
+++ b/src/main/java/com/can/config/AppProperties.java
@@ -53,6 +53,41 @@ public interface AppProperties
 
         @WithDefault("1")
         int replicationFactor();
+
+        Discovery discovery();
+
+        Replication replication();
+    }
+
+    interface Discovery {
+        @WithDefault("230.0.0.1")
+        String multicastGroup();
+
+        @WithDefault("45565")
+        int multicastPort();
+
+        @WithDefault("5000")
+        long heartbeatIntervalMillis();
+
+        @WithDefault("15000")
+        long failureTimeoutMillis();
+
+        @WithDefault("")
+        String nodeId();
+    }
+
+    interface Replication {
+        @WithDefault("0.0.0.0")
+        String bindHost();
+
+        @WithDefault("127.0.0.1")
+        String advertiseHost();
+
+        @WithDefault("18080")
+        int port();
+
+        @WithDefault("5000")
+        int connectTimeoutMillis();
     }
 
     interface Network {

--- a/src/test/java/com/can/cluster/coordination/ReplicationProtocolTest.java
+++ b/src/test/java/com/can/cluster/coordination/ReplicationProtocolTest.java
@@ -1,0 +1,210 @@
+package com.can.cluster.coordination;
+
+import com.can.codec.StringCodec;
+import com.can.config.AppProperties;
+import com.can.core.CacheEngine;
+import com.can.core.EvictionPolicyType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReplicationProtocolTest
+{
+    private CacheEngine<String, String> engine;
+    private ReplicationServer server;
+    private RemoteNode remoteNode;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        int port = availablePort();
+        TestProperties properties = new TestProperties(port);
+        engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                .segments(2)
+                .maxCapacity(128)
+                .cleanerPollMillis(25)
+                .evictionPolicy(EvictionPolicyType.LRU)
+                .build();
+
+        server = new ReplicationServer(engine, properties);
+        server.start();
+
+        remoteNode = new RemoteNode("remote", properties.cluster().replication().advertiseHost(), port,
+                properties.cluster().replication().connectTimeoutMillis());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.close();
+        }
+        if (engine != null) {
+            engine.close();
+        }
+    }
+
+    @Test
+    void remoteSetAndGetShouldReplicateToEngine() {
+        remoteNode.set("foo", "bar", Duration.ofSeconds(1));
+
+        assertEquals("bar", engine.get("foo"));
+        assertEquals("bar", remoteNode.get("foo"));
+    }
+
+    @Test
+    void remoteDeleteShouldRemoveEntry() {
+        remoteNode.set("hello", "world", Duration.ofSeconds(5));
+        assertTrue(engine.exists("hello"));
+
+        assertTrue(remoteNode.delete("hello"));
+        assertFalse(engine.exists("hello"));
+    }
+
+    @Test
+    void ttlShouldBeRespectedAcrossReplication() throws InterruptedException {
+        remoteNode.set("short", "lived", Duration.ofMillis(150));
+        assertTrue(engine.exists("short"));
+
+        Thread.sleep(400);
+
+        assertFalse(engine.exists("short"));
+        assertNull(remoteNode.get("short"));
+    }
+
+    private static int availablePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        }
+    }
+
+    private static final class TestProperties implements AppProperties {
+        private final Cluster cluster;
+        private final Network network = new Network() {
+            @Override
+            public String host() { return "127.0.0.1"; }
+
+            @Override
+            public int port() { return 11211; }
+
+            @Override
+            public int backlog() { return 16; }
+
+            @Override
+            public int workerThreads() { return 4; }
+        };
+
+        private TestProperties(int port) {
+            this.cluster = new TestCluster(port);
+        }
+
+        @Override
+        public Metrics metrics() {
+            return () -> 5L;
+        }
+
+        @Override
+        public Rdb rdb() {
+            return new Rdb() {
+                @Override
+                public String path() { return "target/test.rdb"; }
+
+                @Override
+                public long snapshotIntervalSeconds() { return 60; }
+            };
+        }
+
+        @Override
+        public Cache cache() {
+            return new Cache() {
+                @Override
+                public int segments() { return 2; }
+
+                @Override
+                public int maxCapacity() { return 256; }
+
+                @Override
+                public long cleanerPollMillis() { return 25; }
+
+                @Override
+                public String evictionPolicy() { return "LRU"; }
+            };
+        }
+
+        @Override
+        public Cluster cluster() {
+            return cluster;
+        }
+
+        @Override
+        public Network network() {
+            return network;
+        }
+    }
+
+    private static final class TestCluster implements AppProperties.Cluster {
+        private final Discovery discovery = new TestDiscovery();
+        private final Replication replication;
+
+        private TestCluster(int port) {
+            this.replication = new TestReplication(port);
+        }
+
+        @Override
+        public int virtualNodes() { return 16; }
+
+        @Override
+        public int replicationFactor() { return 1; }
+
+        @Override
+        public Discovery discovery() { return discovery; }
+
+        @Override
+        public Replication replication() { return replication; }
+    }
+
+    private static final class TestDiscovery implements AppProperties.Discovery {
+        @Override
+        public String multicastGroup() { return "230.0.0.1"; }
+
+        @Override
+        public int multicastPort() { return 45565; }
+
+        @Override
+        public long heartbeatIntervalMillis() { return 2000; }
+
+        @Override
+        public long failureTimeoutMillis() { return 6000; }
+
+        @Override
+        public String nodeId() { return "test-node"; }
+    }
+
+    private static final class TestReplication implements AppProperties.Replication {
+        private final int port;
+
+        private TestReplication(int port) {
+            this.port = port;
+        }
+
+        @Override
+        public String bindHost() { return "127.0.0.1"; }
+
+        @Override
+        public String advertiseHost() { return "127.0.0.1"; }
+
+        @Override
+        public int port() { return port; }
+
+        @Override
+        public int connectTimeoutMillis() { return 2000; }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a multicast-based coordination service that auto-discovers peers, keeps the hash ring up to date, and cleans up timed-out members
- add a lightweight replication TCP server plus remote node proxy so cache operations are forwarded to other JVMs without re-entering the client layer
- extend the application configuration and CDI wiring to derive node identifiers from discovery settings and expose the replication protocol alongside a regression test for the protocol

## Testing
- `mvn -q test` *(fails: repository download blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68d1265d4b4c83238ae3b478c3c4bb63