### PR TITLE
Refactor lifecycle-managed beans to CDI singletons

### DIFF
--- a/src/main/java/com/can/config/AppConfig.java
+++ b/src/main/java/com/can/config/AppConfig.java
@@ -9,9 +9,7 @@ import com.can.codec.StringCodec;
 import com.can.core.CacheEngine;
 import com.can.core.EvictionPolicyType;
 import com.can.metric.MetricsRegistry;
-import com.can.metric.MetricsReporter;
 import com.can.rdb.SnapshotFile;
-import com.can.rdb.SnapshotScheduler;
 import com.can.pubsub.Broker;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Disposes;
@@ -48,30 +46,11 @@ public class AppConfig {
 
     @Produces
     @Singleton
-    public MetricsReporter metricsReporter(MetricsRegistry registry) {
-        long interval = properties.metrics().reportIntervalSeconds();
-        MetricsReporter reporter = new MetricsReporter(registry);
-        reporter.start(interval);
-        return reporter;
-    }
-
-    void disposeMetricsReporter(@Disposes MetricsReporter reporter) {
-        reporter.close();
-    }
-
-    @Produces
-    @Singleton
-    public Broker broker() {
-        return new Broker();
-    }
-
-    void disposeBroker(@Disposes Broker broker) {
-        broker.close();
-    }
-
-    @Produces
-    @Singleton
-    public CacheEngine<String, String> cacheEngine(MetricsRegistry metrics, Broker broker, SnapshotFile<String, String> snapshotFile) {
+    public CacheEngine<String, String> cacheEngine(
+            MetricsRegistry metrics,
+            Broker broker,
+            SnapshotFile<String, String> snapshotFile
+    ) {
         var cacheProps = properties.cache();
         CacheEngine<String, String> engine =
                 CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
@@ -99,20 +78,6 @@ public class AppConfig {
                 new File(rdbProps.path()),
                 StringCodec.UTF8
         );
-    }
-
-    @Produces
-    @Singleton
-    public SnapshotScheduler<String, String> snapshotScheduler(CacheEngine<String, String> engine,
-                                                               SnapshotFile<String, String> snapshotFile) {
-        long interval = properties.rdb().snapshotIntervalSeconds();
-        SnapshotScheduler<String, String> scheduler = new SnapshotScheduler<>(engine, snapshotFile, interval);
-        scheduler.start();
-        return scheduler;
-    }
-
-    void disposeSnapshotScheduler(@Disposes SnapshotScheduler<String, String> scheduler) {
-        scheduler.close();
     }
 
     @Produces

--- a/src/main/java/com/can/metric/MetricsReporter.java
+++ b/src/main/java/com/can/metric/MetricsReporter.java
@@ -1,35 +1,89 @@
 package com.can.metric;
 
+import com.can.config.AppProperties;
+import io.quarkus.runtime.Startup;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Metrik kayıt defterindeki sayaç ve zamanlayıcıları belirli aralıklarla konsola
  * raporlayan yardımcı servistir. Sanal thread'ler üzerinden çalışan zamanlayıcı
  * görevleri yönetir ve kapatıldığında kaynakları serbest bırakır.
  */
-public final class MetricsReporter implements AutoCloseable
-{
-    private final MetricsRegistry reg;
-    private final ScheduledExecutorService exec =
-            Executors.newScheduledThreadPool(2, Thread.ofVirtual().factory());
+@Startup
+@Singleton
+public class MetricsReporter implements AutoCloseable {
 
-    public MetricsReporter(MetricsRegistry reg){ this.reg = reg; }
-    public void start(long intervalSeconds){ exec.scheduleAtFixedRate(this::dump,
-            intervalSeconds, intervalSeconds, TimeUnit.SECONDS); }
+    private final MetricsRegistry registry;
+    private final long intervalSeconds;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private ScheduledExecutorService executor;
 
-    private void dump()
-    {
-        IO.println("=== METRICS ====");
-        for (var c : reg.counters().values()) System.out.printf("counter %s = %d%n", c.name(), c.get());
-        for (var t : reg.timers().values()){
-            var s = t.snapshot();
-            System.out.printf("timer %s count=%d avg=%.2fµs p50=%.2fµs p95=%.2fµs min=%.2fµs max=%.2fµs%n",
-                    s.name(), s.count(), s.avgNs()/1_000.0, s.p50Ns()/1_000.0, s.p95Ns()/1_000.0, s.minNs()/1_000.0, s.maxNs()/1_000.0);
+    @Inject
+    public MetricsReporter(MetricsRegistry registry, AppProperties properties) {
+        this(registry, properties.metrics().reportIntervalSeconds());
+    }
+
+    public MetricsReporter(MetricsRegistry registry, long intervalSeconds) {
+        this.registry = registry;
+        this.intervalSeconds = intervalSeconds;
+    }
+
+    @PostConstruct
+    void init() {
+        start(intervalSeconds);
+    }
+
+    public synchronized void start(long intervalSeconds) {
+        if (intervalSeconds <= 0 || !running.compareAndSet(false, true)) {
+            return;
         }
+        executor = Executors.newScheduledThreadPool(2, Thread.ofVirtual().factory());
+        executor.scheduleAtFixedRate(this::dump, intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
+    }
+
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    private void dump() {
+        System.out.println("=== METRICS ====");
+        registry.counters().values().forEach(counter ->
+                System.out.printf("counter %s = %d%n", counter.name(), counter.get())
+        );
+        registry.timers().values().forEach(timer -> {
+            var sample = timer.snapshot();
+            System.out.printf(
+                    "timer %s count=%d avg=%.2fµs p50=%.2fµs p95=%.2fµs min=%.2fµs max=%.2fµs%n",
+                    sample.name(),
+                    sample.count(),
+                    sample.avgNs() / 1_000.0,
+                    sample.p50Ns() / 1_000.0,
+                    sample.p95Ns() / 1_000.0,
+                    sample.minNs() / 1_000.0,
+                    sample.maxNs() / 1_000.0
+            );
+        });
+    }
+
+    @PreDestroy
+    void shutdown() {
+        close();
     }
 
     @Override
-    public void close(){ exec.shutdownNow(); }
+    public synchronized void close() {
+        running.set(false);
+        if (executor != null) {
+            executor.shutdownNow();
+            executor = null;
+        }
+    }
 }

--- a/src/main/java/com/can/pubsub/Broker.java
+++ b/src/main/java/com/can/pubsub/Broker.java
@@ -1,6 +1,15 @@
 package com.can.pubsub;
 
-import java.util.concurrent.*;
+import io.quarkus.runtime.Startup;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
 /**
@@ -9,24 +18,60 @@ import java.util.function.Consumer;
  * üzerinden her mesajı abonelere asenkron iletir ve abonelik yaşam döngüsünü
  * yönetir.
  */
-public final class Broker implements AutoCloseable
-{
-    private final ConcurrentMap<String, CopyOnWriteArrayList<Consumer<byte[]>>> subs = new ConcurrentHashMap<>();
-    private final ExecutorService exec = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory());
+@Startup
+@Singleton
+public class Broker implements AutoCloseable {
 
-    public void publish(String topic, byte[] payload)
-    {
-        var list = subs.get(topic);
-        if (list == null) return;
-        for (var c : list) exec.submit(() -> c.accept(payload));
+    private final ConcurrentMap<String, CopyOnWriteArrayList<Consumer<byte[]>>> subscriptions = new ConcurrentHashMap<>();
+    private volatile ExecutorService executor;
+
+    @PostConstruct
+    void init() {
+        ensureExecutor();
     }
 
-    public AutoCloseable subscribe(String topic, Consumer<byte[]> consumer)
-    {
-        subs.computeIfAbsent(topic, k -> new CopyOnWriteArrayList<>()).add(consumer);
-        return () -> subs.getOrDefault(topic, new CopyOnWriteArrayList<>()).remove(consumer);
+    public void publish(String topic, byte[] payload) {
+        var list = subscriptions.get(topic);
+        if (list == null || list.isEmpty()) {
+            return;
+        }
+        ExecutorService current = ensureExecutor();
+        for (var consumer : list) {
+            current.submit(() -> consumer.accept(payload));
+        }
+    }
+
+    public AutoCloseable subscribe(String topic, Consumer<byte[]> consumer) {
+        subscriptions.computeIfAbsent(topic, key -> new CopyOnWriteArrayList<>()).add(consumer);
+        ensureExecutor();
+        return () -> subscriptions.getOrDefault(topic, new CopyOnWriteArrayList<>()).remove(consumer);
+    }
+
+    public boolean isRunning() {
+        ExecutorService current = executor;
+        return current != null && !current.isShutdown();
+    }
+
+    @PreDestroy
+    void shutdown() {
+        close();
     }
 
     @Override
-    public void close() { exec.shutdownNow(); subs.clear(); }
+    public synchronized void close() {
+        ExecutorService current = executor;
+        if (current != null) {
+            current.shutdownNow();
+            executor = null;
+        }
+        subscriptions.clear();
+    }
+
+    private synchronized ExecutorService ensureExecutor() {
+        ExecutorService current = executor;
+        if (current == null || current.isShutdown()) {
+            executor = current = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory());
+        }
+        return current;
+    }
 }

--- a/src/main/java/com/can/rdb/SnapshotScheduler.java
+++ b/src/main/java/com/can/rdb/SnapshotScheduler.java
@@ -1,6 +1,12 @@
 package com.can.rdb;
 
+import com.can.config.AppProperties;
 import com.can.core.CacheEngine;
+import io.quarkus.runtime.Startup;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.jboss.logging.Logger;
 
 import java.util.concurrent.Executors;
@@ -15,44 +21,71 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@link SnapshotFile#write(CacheEngine)} çağrısını gerçekleştirir ve hata
  * durumlarını loglayarak sistemin ayakta kalmasını sağlar.
  */
-public final class SnapshotScheduler<K, V> implements AutoCloseable
-{
+@Startup
+@Singleton
+public class SnapshotScheduler<K, V> implements AutoCloseable {
+
     private static final Logger LOG = Logger.getLogger(SnapshotScheduler.class);
 
     private final CacheEngine<K, V> engine;
     private final SnapshotFile<K, V> snapshotFile;
     private final long intervalSeconds;
-    private final ScheduledExecutorService executor;
     private final AtomicBoolean started = new AtomicBoolean(false);
+    private ScheduledExecutorService executor;
+
+    @Inject
+    public SnapshotScheduler(CacheEngine<K, V> engine, SnapshotFile<K, V> snapshotFile, AppProperties properties) {
+        this(engine, snapshotFile, properties.rdb().snapshotIntervalSeconds());
+    }
 
     public SnapshotScheduler(CacheEngine<K, V> engine, SnapshotFile<K, V> snapshotFile, long intervalSeconds) {
         this.engine = engine;
         this.snapshotFile = snapshotFile;
         this.intervalSeconds = intervalSeconds;
-        this.executor = Executors.newSingleThreadScheduledExecutor(Thread.ofVirtual().factory());
     }
 
-    public void start() {
-        if (!started.compareAndSet(false, true)) {
+    @PostConstruct
+    void init() {
+        start();
+    }
+
+    public synchronized void start() {
+        if (started.get()) {
             return;
         }
+        executor = Executors.newSingleThreadScheduledExecutor(Thread.ofVirtual().factory());
+        started.set(true);
         executor.execute(this::safeSnapshot);
         if (intervalSeconds > 0) {
             executor.scheduleWithFixedDelay(this::safeSnapshot, intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
         }
     }
 
+    public boolean isRunning() {
+        return started.get();
+    }
+
     private void safeSnapshot() {
         try {
             snapshotFile.write(engine);
-        } catch (Throwable t)
-        {
-            LOG.log(Logger.Level.ERROR,t .getMessage());
+        } catch (Throwable t) {
+            LOG.error("Failed to persist snapshot", t);
         }
     }
 
+    @PreDestroy
+    void shutdown() {
+        close();
+    }
+
     @Override
-    public void close() {
-        executor.shutdownNow();
+    public synchronized void close() {
+        if (!started.getAndSet(false)) {
+            return;
+        }
+        if (executor != null) {
+            executor.shutdownNow();
+            executor = null;
+        }
     }
 }

--- a/src/test/java/com/can/config/LifecycleManagedBeansTest.java
+++ b/src/test/java/com/can/config/LifecycleManagedBeansTest.java
@@ -1,0 +1,53 @@
+package com.can.config;
+
+import com.can.metric.MetricsReporter;
+import com.can.pubsub.Broker;
+import com.can.rdb.SnapshotScheduler;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class LifecycleManagedBeansTest {
+
+    @Inject
+    MetricsReporter reporter;
+
+    @Inject
+    SnapshotScheduler<String, String> scheduler;
+
+    @Inject
+    Broker broker;
+
+    @Inject
+    AppProperties properties;
+
+    @Test
+    void metricsReporterPreDestroyStopsScheduling() {
+        assertTrue(reporter.isRunning());
+        reporter.close();
+        assertFalse(reporter.isRunning());
+        reporter.start(properties.metrics().reportIntervalSeconds());
+    }
+
+    @Test
+    void snapshotSchedulerPreDestroyStopsScheduling() {
+        assertTrue(scheduler.isRunning());
+        scheduler.close();
+        assertFalse(scheduler.isRunning());
+        scheduler.start();
+    }
+
+    @Test
+    void brokerPreDestroyStopsExecutor() throws Exception {
+        assertTrue(broker.isRunning());
+        broker.close();
+        assertFalse(broker.isRunning());
+        try (AutoCloseable ignored = broker.subscribe("lifecycle", payload -> { })) {
+            assertTrue(broker.isRunning());
+        }
+    }
+}

--- a/src/test/java/com/can/metric/MetricsComponentsTest.java
+++ b/src/test/java/com/can/metric/MetricsComponentsTest.java
@@ -86,13 +86,13 @@ class MetricsComponentsTest {
             originalOut = System.out;
             System.setOut(new PrintStream(baos));
 
-            reporter = new MetricsReporter(registry);
+            reporter = new MetricsReporter(registry, 1);
             reporter.start(1);
 
             Thread.sleep(1_200); // en az bir dump çağrısı gerçekleşsin
 
             String output = baos.toString();
-            assertTrue(output.contains("=== metrics ==="));
+            assertTrue(output.contains("=== METRICS ===="));
             assertTrue(output.contains("counter c = 2"));
             assertTrue(output.contains("timer t"));
         }


### PR DESCRIPTION
## Summary
- annotate MetricsReporter, Broker, and SnapshotScheduler as @Startup singletons with internal @PostConstruct/@PreDestroy lifecycle handling and AppProperties-driven configuration
- streamline AppConfig producers to rely on CDI-managed beans and update MetricsReporter/SnapshotScheduler APIs for reuse in tests
- adjust existing tests and add a Quarkus lifecycle test to cover the new shutdown behaviour

## Testing
- `mvn test` *(fails: repository download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d1445700e88323886513b9ed68165e