### PR TITLE
Add Docker-based integration test for memcached protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,13 @@
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.20.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -64,6 +71,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/com/can/CanCacheDockerIT.java
+++ b/src/test/java/com/can/CanCacheDockerIT.java
@@ -1,0 +1,107 @@
+package com.can;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Uygulamanın Docker içinde ayağa kalktığında memcached metin protokolüne
+ * cevap verdiğini doğrulayan entegrasyon testi.
+ */
+class CanCacheDockerIT {
+
+    private static final Path QUARKUS_APP_DIR = Path.of("target", "quarkus-app");
+    private static GenericContainer<?> appContainer;
+
+    @BeforeAll
+    static void startApplicationContainer() {
+        Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(),
+                "Docker runtime is required for integration tests");
+        Assumptions.assumeTrue(Files.exists(QUARKUS_APP_DIR.resolve("quarkus-run.jar")),
+                "Quarkus application must be packaged before running integration tests");
+
+        appContainer = new GenericContainer<>("eclipse-temurin:25-jre")
+                .withCopyFileToContainer(MountableFile.forHostPath(QUARKUS_APP_DIR.toAbsolutePath()), "/opt/can-cache")
+                .withWorkingDirectory("/opt/can-cache")
+                .withCommand("java", "-jar", "quarkus-run.jar")
+                .withExposedPorts(11211)
+                .waitingFor(Wait.forLogMessage(".*Memcached-compatible server listening.*", 1))
+                .withStartupTimeout(Duration.ofSeconds(60));
+        appContainer.start();
+    }
+
+    @AfterAll
+    static void stopApplicationContainer() {
+        if (appContainer != null) {
+            appContainer.stop();
+        }
+    }
+
+    @Test
+    void shouldStoreRetrieveAndDeleteValueThroughMemcachedProtocol() throws Exception {
+        Assumptions.assumeTrue(appContainer != null && appContainer.isRunning(),
+                "Application container did not start");
+
+        try (Socket socket = new Socket(appContainer.getHost(), appContainer.getMappedPort(11211));
+             BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.US_ASCII))) {
+
+            socket.setSoTimeout(5000);
+
+            String cacheKey = "integration-key";
+            String cacheValue = "docker-test";
+
+            sendCommand(writer, "set " + cacheKey + " 0 60 " + cacheValue.length(), cacheValue);
+            assertEquals("STORED", reader.readLine(), "Value should be stored successfully");
+
+            sendCommand(writer, "get " + cacheKey, null);
+            String header = reader.readLine();
+            assertNotNull(header, "Memcached response must not be null");
+            String[] headerParts = header.split(" ");
+            assertEquals(4, headerParts.length, "Memcached VALUE header should have four parts");
+            assertEquals("VALUE", headerParts[0]);
+            assertEquals(cacheKey, headerParts[1]);
+            assertEquals("0", headerParts[2]);
+            assertEquals(String.valueOf(cacheValue.length()), headerParts[3]);
+            assertEquals(cacheValue, reader.readLine(), "Returned payload should match stored value");
+            assertEquals("END", reader.readLine(), "Memcached get should terminate with END");
+
+            sendCommand(writer, "delete " + cacheKey, null);
+            assertEquals("DELETED", reader.readLine(), "Delete operation should report success");
+
+            sendCommand(writer, "get " + cacheKey, null);
+            String endLine = reader.readLine();
+            assertNotNull(endLine, "Response after delete should not be null");
+            assertEquals("END", endLine, "Deleted key should not be returned again");
+        }
+    }
+
+    private static void sendCommand(BufferedWriter writer, String command, String payload) throws IOException {
+        writer.write(command);
+        writer.write("\r\n");
+        if (payload != null) {
+            writer.write(payload);
+            writer.write("\r\n");
+        }
+        writer.flush();
+    }
+}


### PR DESCRIPTION
## Summary
- add Testcontainers support and failsafe execution so integration tests can run after packaging
- introduce a Docker-driven integration test that boots the Quarkus cache service and exercises the Memcached text commands

## Testing
- `mvn verify` *(fails: unable to reach Maven Central due to restricted network access in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d166ba6aec83239ae781078ba6556c