### PR TITLE
Add JMeter performance test plans and NFRs

### DIFF
--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -1,0 +1,60 @@
+# JMeter Load Test Suite for Can Cache
+
+This directory contains non-functional performance tests for the Can Cache
+Memcached-compatible TCP service. The scenarios are grouped by target load
+profile and can be executed with the Apache JMeter command line interface.
+
+## Prerequisites
+
+* Apache JMeter 5.6 or newer with the bundled Groovy runtime.
+* A running Can Cache instance that listens on the Memcached port (default
+  `127.0.0.1:11211`). Start the application with `./mvnw quarkus:dev` or use the
+  packaged JAR as described in the project README.
+* Optional: a writable `results/` directory to store `.jtl` output files. The
+  paths can be overridden with JMeter properties.
+
+## Running the plans
+
+Each load profile has its own `.jmx` file under `performance-tests/jmeter` and a
+corresponding non-functional requirement (NFR) under `performance-tests/nfr`.
+Execute a plan with the JMeter CLI:
+
+```bash
+jmeter -n \
+  -t performance-tests/jmeter/can-cache-small.jmx \
+  -l results/can-cache-small.jtl \
+  -JtargetHost=127.0.0.1 \
+  -JtargetPort=11211
+```
+
+Commonly used override properties:
+
+| Property | Description | Default |
+| --- | --- | --- |
+| `targetHost` | Hostname or IP of the Can Cache node. | `127.0.0.1` |
+| `targetPort` | TCP port of the Memcached endpoint. | `11211` |
+| `ttlSeconds` | TTL assigned to the `set` command. | `60` |
+| `connectTimeoutMillis` | Socket connect timeout in milliseconds. | `1000` |
+| `readTimeoutMillis` | Socket read timeout in milliseconds. | `3000` |
+| `keyPrefix` | Prefix used for generated cache keys. | `perf-` |
+| `payloadSize` | Size of the generated payload in bytes (plan-specific default). | varies |
+| `durationSeconds` | Total runtime of the thread group (plan-specific default). | varies |
+| `resultFile` | Output `.jtl` path for aggregated metrics. | varies |
+
+All plans rely on a Groovy JSR223 sampler that performs a full Memcached
+round-trip (set, get, delete) and validates responses. The thread groups run for
+fixed durations with no loop limits to make the execution time deterministic.
+Adjust thread counts, payload sizes, or timers in each plan to tune the pressure
+exerted on the cache node.
+
+## Load profiles
+
+| Profile | Threads | Ramp-up | Duration | Payload | Think time | Purpose |
+| --- | --- | --- | --- | --- | --- | --- |
+| Small (`can-cache-small.jmx`) | 5 | 10 s | 120 s | 64 B | 100 ms | Baseline health & smoke under light load. |
+| Medium (`can-cache-medium.jmx`) | 20 | 30 s | 300 s | 128 B | 75 ms | Steady mid-tier concurrency to validate scaling behavior. |
+| Large (`can-cache-large.jmx`) | 50 | 60 s | 600 s | 256 B | 50 ms | High concurrency stressing CPU and network queues. |
+| Extra Large (`can-cache-xl.jmx`) | 100 | 90 s | 900 s | 512 B | 25 ms | Saturation-level workload for capacity planning. |
+
+Review the matching NFR files for success criteria, latency/error budgets, and
+operational guardrails associated with each load level.

--- a/performance-tests/jmeter/can-cache-large.jmx
+++ b/performance-tests/jmeter/can-cache-large.jmx
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.2">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Can Cache Large Load" enabled="true">
+      <stringProp name="TestPlan.comments">High concurrency stress profile</stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="targetHost" elementType="Argument">
+            <stringProp name="Argument.name">targetHost</stringProp>
+            <stringProp name="Argument.value">${__P(targetHost,127.0.0.1)}</stringProp>
+            <stringProp name="Argument.desc">Hostname of the Can Cache node</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="targetPort" elementType="Argument">
+            <stringProp name="Argument.name">targetPort</stringProp>
+            <stringProp name="Argument.value">${__P(targetPort,11211)}</stringProp>
+            <stringProp name="Argument.desc">Memcached TCP port</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="ttlSeconds" elementType="Argument">
+            <stringProp name="Argument.name">ttlSeconds</stringProp>
+            <stringProp name="Argument.value">${__P(ttlSeconds,60)}</stringProp>
+            <stringProp name="Argument.desc">TTL assigned to SET</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="connectTimeoutMillis" elementType="Argument">
+            <stringProp name="Argument.name">connectTimeoutMillis</stringProp>
+            <stringProp name="Argument.value">${__P(connectTimeoutMillis,1000)}</stringProp>
+            <stringProp name="Argument.desc">Socket connect timeout</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="readTimeoutMillis" elementType="Argument">
+            <stringProp name="Argument.name">readTimeoutMillis</stringProp>
+            <stringProp name="Argument.value">${__P(readTimeoutMillis,3000)}</stringProp>
+            <stringProp name="Argument.desc">Socket read timeout</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="keyPrefix" elementType="Argument">
+            <stringProp name="Argument.name">keyPrefix</stringProp>
+            <stringProp name="Argument.value">${__P(keyPrefix,perf-)}</stringProp>
+            <stringProp name="Argument.desc">Prefix for generated keys</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="payloadSize" elementType="Argument">
+            <stringProp name="Argument.name">payloadSize</stringProp>
+            <stringProp name="Argument.value">${__P(payloadSize,256)}</stringProp>
+            <stringProp name="Argument.desc">Payload size in bytes</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="durationSeconds" elementType="Argument">
+            <stringProp name="Argument.name">durationSeconds</stringProp>
+            <stringProp name="Argument.value">${__P(durationSeconds,600)}</stringProp>
+            <stringProp name="Argument.desc">Thread group duration</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="resultFile" elementType="Argument">
+            <stringProp name="Argument.name">resultFile</stringProp>
+            <stringProp name="Argument.value">${__P(resultFile,results/can-cache-large.jtl)}</stringProp>
+            <stringProp name="Argument.desc">Results output path</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"/>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Large Load Threads" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loops" enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">-1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">50</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">60</stringProp>
+        <longProp name="ThreadGroup.start_time">0</longProp>
+        <longProp name="ThreadGroup.end_time">0</longProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${durationSeconds}</stringProp>
+        <stringProp name="ThreadGroup.delay">0</stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="Memcached Round Trip" enabled="true">
+          <stringProp name="cacheKey">groovy-memcached-roundtrip</stringProp>
+          <stringProp name="filename"/>
+          <stringProp name="parameters"/>
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="script"><![CDATA[import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.util.UUID
+
+def host = vars.get("targetHost")
+int port = (vars.get("targetPort") ?: "11211") as int
+int ttl = (vars.get("ttlSeconds") ?: "60") as int
+int payloadSize = (vars.get("payloadSize") ?: "256") as int
+int connectTimeout = (vars.get("connectTimeoutMillis") ?: "1000") as int
+int readTimeout = (vars.get("readTimeoutMillis") ?: "3000") as int
+def keyPrefix = vars.get("keyPrefix") ?: "perf-"
+
+Socket socket
+BufferedWriter writer
+BufferedReader reader
+
+SampleResult.sampleStart()
+try {
+    socket = new Socket()
+    socket.connect(new InetSocketAddress(host, port), connectTimeout)
+    socket.soTimeout = readTimeout
+    socket.tcpNoDelay = true
+
+    writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), "UTF-8"))
+    reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), "UTF-8"))
+
+    def random = UUID.randomUUID().toString().replace("-", "")
+    int repeat = Math.max(1, (int) Math.ceil(payloadSize / (double) random.length()))
+    def payloadSource = random * repeat
+    def payload = payloadSource.substring(0, payloadSize)
+    byte[] payloadBytes = payload.getBytes("UTF-8")
+    def key = keyPrefix + random.substring(0, Math.min(16, random.length()))
+
+    writer.write("set ${key} 0 ${ttl} ${payloadBytes.length}\\r\\n")
+    writer.write(payload)
+    writer.write("\\r\\n")
+    writer.flush()
+
+    def setResp = reader.readLine()
+    if (!"STORED".equals(setResp)) {
+        throw new IOException("SET failed with response: ${setResp}")
+    }
+
+    writer.write("get ${key}\\r\\n")
+    writer.flush()
+
+    def header = reader.readLine()
+    if (header == null || !header.startsWith("VALUE")) {
+        throw new IOException("Unexpected GET header: ${header}")
+    }
+
+    def returned = reader.readLine()
+    def trailer = reader.readLine()
+    if (!payload.equals(returned)) {
+        throw new IOException("Returned payload mismatch (${returned?.length()} vs expected ${payload.length()})")
+    }
+    if (!"END".equals(trailer)) {
+        throw new IOException("Missing END after GET, received: ${trailer}")
+    }
+
+    writer.write("delete ${key}\\r\\n")
+    writer.flush()
+    def deleteResp = reader.readLine()
+    if (deleteResp == null || !(deleteResp.equals("DELETED") || deleteResp.equals("NOT_FOUND"))) {
+        throw new IOException("DELETE failed with response: ${deleteResp}")
+    }
+
+    SampleResult.setResponseCodeOK()
+    SampleResult.setResponseMessage("Round trip succeeded")
+    SampleResult.setResponseData(("SET:${setResp};GET:${header};DEL:${deleteResp}").getBytes("UTF-8"))
+    SampleResult.setSuccessful(true)
+} catch (Exception ex) {
+    log.error("Memcached round trip failed", ex)
+    SampleResult.setSuccessful(false)
+    SampleResult.setResponseCode("500")
+    SampleResult.setResponseMessage(ex.getMessage())
+    def sw = new StringWriter()
+    ex.printStackTrace(new PrintWriter(sw))
+    SampleResult.setResponseData(sw.toString(), "UTF-8")
+} finally {
+    SampleResult.sampleEnd()
+    try {
+        writer?.close()
+    } catch (Exception ignore) {}
+    try {
+        reader?.close()
+    } catch (Exception ignore) {}
+    try {
+        socket?.close()
+    } catch (Exception ignore) {}
+}
+]]></stringProp>
+        </JSR223Sampler>
+        <hashTree/>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Think Time" enabled="true">
+          <stringProp name="ConstantTimer.delay">50</stringProp>
+        </ConstantTimer>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">${resultFile}</stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/performance-tests/jmeter/can-cache-medium.jmx
+++ b/performance-tests/jmeter/can-cache-medium.jmx
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.2">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Can Cache Medium Load" enabled="true">
+      <stringProp name="TestPlan.comments">Moderate concurrency profile</stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="targetHost" elementType="Argument">
+            <stringProp name="Argument.name">targetHost</stringProp>
+            <stringProp name="Argument.value">${__P(targetHost,127.0.0.1)}</stringProp>
+            <stringProp name="Argument.desc">Hostname of the Can Cache node</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="targetPort" elementType="Argument">
+            <stringProp name="Argument.name">targetPort</stringProp>
+            <stringProp name="Argument.value">${__P(targetPort,11211)}</stringProp>
+            <stringProp name="Argument.desc">Memcached TCP port</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="ttlSeconds" elementType="Argument">
+            <stringProp name="Argument.name">ttlSeconds</stringProp>
+            <stringProp name="Argument.value">${__P(ttlSeconds,60)}</stringProp>
+            <stringProp name="Argument.desc">TTL assigned to SET</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="connectTimeoutMillis" elementType="Argument">
+            <stringProp name="Argument.name">connectTimeoutMillis</stringProp>
+            <stringProp name="Argument.value">${__P(connectTimeoutMillis,1000)}</stringProp>
+            <stringProp name="Argument.desc">Socket connect timeout</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="readTimeoutMillis" elementType="Argument">
+            <stringProp name="Argument.name">readTimeoutMillis</stringProp>
+            <stringProp name="Argument.value">${__P(readTimeoutMillis,3000)}</stringProp>
+            <stringProp name="Argument.desc">Socket read timeout</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="keyPrefix" elementType="Argument">
+            <stringProp name="Argument.name">keyPrefix</stringProp>
+            <stringProp name="Argument.value">${__P(keyPrefix,perf-)}</stringProp>
+            <stringProp name="Argument.desc">Prefix for generated keys</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="payloadSize" elementType="Argument">
+            <stringProp name="Argument.name">payloadSize</stringProp>
+            <stringProp name="Argument.value">${__P(payloadSize,128)}</stringProp>
+            <stringProp name="Argument.desc">Payload size in bytes</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="durationSeconds" elementType="Argument">
+            <stringProp name="Argument.name">durationSeconds</stringProp>
+            <stringProp name="Argument.value">${__P(durationSeconds,300)}</stringProp>
+            <stringProp name="Argument.desc">Thread group duration</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="resultFile" elementType="Argument">
+            <stringProp name="Argument.name">resultFile</stringProp>
+            <stringProp name="Argument.value">${__P(resultFile,results/can-cache-medium.jtl)}</stringProp>
+            <stringProp name="Argument.desc">Results output path</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"/>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Medium Load Threads" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loops" enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">-1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">20</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">30</stringProp>
+        <longProp name="ThreadGroup.start_time">0</longProp>
+        <longProp name="ThreadGroup.end_time">0</longProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${durationSeconds}</stringProp>
+        <stringProp name="ThreadGroup.delay">0</stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="Memcached Round Trip" enabled="true">
+          <stringProp name="cacheKey">groovy-memcached-roundtrip</stringProp>
+          <stringProp name="filename"/>
+          <stringProp name="parameters"/>
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="script"><![CDATA[import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.util.UUID
+
+def host = vars.get("targetHost")
+int port = (vars.get("targetPort") ?: "11211") as int
+int ttl = (vars.get("ttlSeconds") ?: "60") as int
+int payloadSize = (vars.get("payloadSize") ?: "128") as int
+int connectTimeout = (vars.get("connectTimeoutMillis") ?: "1000") as int
+int readTimeout = (vars.get("readTimeoutMillis") ?: "3000") as int
+def keyPrefix = vars.get("keyPrefix") ?: "perf-"
+
+Socket socket
+BufferedWriter writer
+BufferedReader reader
+
+SampleResult.sampleStart()
+try {
+    socket = new Socket()
+    socket.connect(new InetSocketAddress(host, port), connectTimeout)
+    socket.soTimeout = readTimeout
+    socket.tcpNoDelay = true
+
+    writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), "UTF-8"))
+    reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), "UTF-8"))
+
+    def random = UUID.randomUUID().toString().replace("-", "")
+    int repeat = Math.max(1, (int) Math.ceil(payloadSize / (double) random.length()))
+    def payloadSource = random * repeat
+    def payload = payloadSource.substring(0, payloadSize)
+    byte[] payloadBytes = payload.getBytes("UTF-8")
+    def key = keyPrefix + random.substring(0, Math.min(16, random.length()))
+
+    writer.write("set ${key} 0 ${ttl} ${payloadBytes.length}\\r\\n")
+    writer.write(payload)
+    writer.write("\\r\\n")
+    writer.flush()
+
+    def setResp = reader.readLine()
+    if (!"STORED".equals(setResp)) {
+        throw new IOException("SET failed with response: ${setResp}")
+    }
+
+    writer.write("get ${key}\\r\\n")
+    writer.flush()
+
+    def header = reader.readLine()
+    if (header == null || !header.startsWith("VALUE")) {
+        throw new IOException("Unexpected GET header: ${header}")
+    }
+
+    def returned = reader.readLine()
+    def trailer = reader.readLine()
+    if (!payload.equals(returned)) {
+        throw new IOException("Returned payload mismatch (${returned?.length()} vs expected ${payload.length()})")
+    }
+    if (!"END".equals(trailer)) {
+        throw new IOException("Missing END after GET, received: ${trailer}")
+    }
+
+    writer.write("delete ${key}\\r\\n")
+    writer.flush()
+    def deleteResp = reader.readLine()
+    if (deleteResp == null || !(deleteResp.equals("DELETED") || deleteResp.equals("NOT_FOUND"))) {
+        throw new IOException("DELETE failed with response: ${deleteResp}")
+    }
+
+    SampleResult.setResponseCodeOK()
+    SampleResult.setResponseMessage("Round trip succeeded")
+    SampleResult.setResponseData(("SET:${setResp};GET:${header};DEL:${deleteResp}").getBytes("UTF-8"))
+    SampleResult.setSuccessful(true)
+} catch (Exception ex) {
+    log.error("Memcached round trip failed", ex)
+    SampleResult.setSuccessful(false)
+    SampleResult.setResponseCode("500")
+    SampleResult.setResponseMessage(ex.getMessage())
+    def sw = new StringWriter()
+    ex.printStackTrace(new PrintWriter(sw))
+    SampleResult.setResponseData(sw.toString(), "UTF-8")
+} finally {
+    SampleResult.sampleEnd()
+    try {
+        writer?.close()
+    } catch (Exception ignore) {}
+    try {
+        reader?.close()
+    } catch (Exception ignore) {}
+    try {
+        socket?.close()
+    } catch (Exception ignore) {}
+}
+]]></stringProp>
+        </JSR223Sampler>
+        <hashTree/>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Think Time" enabled="true">
+          <stringProp name="ConstantTimer.delay">75</stringProp>
+        </ConstantTimer>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">${resultFile}</stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/performance-tests/jmeter/can-cache-small.jmx
+++ b/performance-tests/jmeter/can-cache-small.jmx
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.2">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Can Cache Small Load" enabled="true">
+      <stringProp name="TestPlan.comments">Lightweight health check profile</stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="targetHost" elementType="Argument">
+            <stringProp name="Argument.name">targetHost</stringProp>
+            <stringProp name="Argument.value">${__P(targetHost,127.0.0.1)}</stringProp>
+            <stringProp name="Argument.desc">Hostname of the Can Cache node</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="targetPort" elementType="Argument">
+            <stringProp name="Argument.name">targetPort</stringProp>
+            <stringProp name="Argument.value">${__P(targetPort,11211)}</stringProp>
+            <stringProp name="Argument.desc">Memcached TCP port</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="ttlSeconds" elementType="Argument">
+            <stringProp name="Argument.name">ttlSeconds</stringProp>
+            <stringProp name="Argument.value">${__P(ttlSeconds,60)}</stringProp>
+            <stringProp name="Argument.desc">TTL assigned to SET</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="connectTimeoutMillis" elementType="Argument">
+            <stringProp name="Argument.name">connectTimeoutMillis</stringProp>
+            <stringProp name="Argument.value">${__P(connectTimeoutMillis,1000)}</stringProp>
+            <stringProp name="Argument.desc">Socket connect timeout</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="readTimeoutMillis" elementType="Argument">
+            <stringProp name="Argument.name">readTimeoutMillis</stringProp>
+            <stringProp name="Argument.value">${__P(readTimeoutMillis,3000)}</stringProp>
+            <stringProp name="Argument.desc">Socket read timeout</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="keyPrefix" elementType="Argument">
+            <stringProp name="Argument.name">keyPrefix</stringProp>
+            <stringProp name="Argument.value">${__P(keyPrefix,perf-)}</stringProp>
+            <stringProp name="Argument.desc">Prefix for generated keys</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="payloadSize" elementType="Argument">
+            <stringProp name="Argument.name">payloadSize</stringProp>
+            <stringProp name="Argument.value">${__P(payloadSize,64)}</stringProp>
+            <stringProp name="Argument.desc">Payload size in bytes</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="durationSeconds" elementType="Argument">
+            <stringProp name="Argument.name">durationSeconds</stringProp>
+            <stringProp name="Argument.value">${__P(durationSeconds,120)}</stringProp>
+            <stringProp name="Argument.desc">Thread group duration</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="resultFile" elementType="Argument">
+            <stringProp name="Argument.name">resultFile</stringProp>
+            <stringProp name="Argument.value">${__P(resultFile,results/can-cache-small.jtl)}</stringProp>
+            <stringProp name="Argument.desc">Results output path</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"/>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Small Load Threads" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loops" enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">-1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">5</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">10</stringProp>
+        <longProp name="ThreadGroup.start_time">0</longProp>
+        <longProp name="ThreadGroup.end_time">0</longProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${durationSeconds}</stringProp>
+        <stringProp name="ThreadGroup.delay">0</stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="Memcached Round Trip" enabled="true">
+          <stringProp name="cacheKey">groovy-memcached-roundtrip</stringProp>
+          <stringProp name="filename"/>
+          <stringProp name="parameters"/>
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="script"><![CDATA[import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.util.UUID
+
+def host = vars.get("targetHost")
+int port = (vars.get("targetPort") ?: "11211") as int
+int ttl = (vars.get("ttlSeconds") ?: "60") as int
+int payloadSize = (vars.get("payloadSize") ?: "64") as int
+int connectTimeout = (vars.get("connectTimeoutMillis") ?: "1000") as int
+int readTimeout = (vars.get("readTimeoutMillis") ?: "3000") as int
+def keyPrefix = vars.get("keyPrefix") ?: "perf-"
+
+Socket socket
+BufferedWriter writer
+BufferedReader reader
+
+SampleResult.sampleStart()
+try {
+    socket = new Socket()
+    socket.connect(new InetSocketAddress(host, port), connectTimeout)
+    socket.soTimeout = readTimeout
+    socket.tcpNoDelay = true
+
+    writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), "UTF-8"))
+    reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), "UTF-8"))
+
+    def random = UUID.randomUUID().toString().replace("-", "")
+    int repeat = Math.max(1, (int) Math.ceil(payloadSize / (double) random.length()))
+    def payloadSource = random * repeat
+    def payload = payloadSource.substring(0, payloadSize)
+    byte[] payloadBytes = payload.getBytes("UTF-8")
+    def key = keyPrefix + random.substring(0, Math.min(16, random.length()))
+
+    writer.write("set ${key} 0 ${ttl} ${payloadBytes.length}\\r\\n")
+    writer.write(payload)
+    writer.write("\\r\\n")
+    writer.flush()
+
+    def setResp = reader.readLine()
+    if (!"STORED".equals(setResp)) {
+        throw new IOException("SET failed with response: ${setResp}")
+    }
+
+    writer.write("get ${key}\\r\\n")
+    writer.flush()
+
+    def header = reader.readLine()
+    if (header == null || !header.startsWith("VALUE")) {
+        throw new IOException("Unexpected GET header: ${header}")
+    }
+
+    def returned = reader.readLine()
+    def trailer = reader.readLine()
+    if (!payload.equals(returned)) {
+        throw new IOException("Returned payload mismatch (${returned?.length()} vs expected ${payload.length()})")
+    }
+    if (!"END".equals(trailer)) {
+        throw new IOException("Missing END after GET, received: ${trailer}")
+    }
+
+    writer.write("delete ${key}\\r\\n")
+    writer.flush()
+    def deleteResp = reader.readLine()
+    if (deleteResp == null || !(deleteResp.equals("DELETED") || deleteResp.equals("NOT_FOUND"))) {
+        throw new IOException("DELETE failed with response: ${deleteResp}")
+    }
+
+    SampleResult.setResponseCodeOK()
+    SampleResult.setResponseMessage("Round trip succeeded")
+    SampleResult.setResponseData(("SET:${setResp};GET:${header};DEL:${deleteResp}").getBytes("UTF-8"))
+    SampleResult.setSuccessful(true)
+} catch (Exception ex) {
+    log.error("Memcached round trip failed", ex)
+    SampleResult.setSuccessful(false)
+    SampleResult.setResponseCode("500")
+    SampleResult.setResponseMessage(ex.getMessage())
+    def sw = new StringWriter()
+    ex.printStackTrace(new PrintWriter(sw))
+    SampleResult.setResponseData(sw.toString(), "UTF-8")
+} finally {
+    SampleResult.sampleEnd()
+    try {
+        writer?.close()
+    } catch (Exception ignore) {}
+    try {
+        reader?.close()
+    } catch (Exception ignore) {}
+    try {
+        socket?.close()
+    } catch (Exception ignore) {}
+}
+]]></stringProp>
+        </JSR223Sampler>
+        <hashTree/>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Think Time" enabled="true">
+          <stringProp name="ConstantTimer.delay">100</stringProp>
+        </ConstantTimer>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">${resultFile}</stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/performance-tests/jmeter/can-cache-xl.jmx
+++ b/performance-tests/jmeter/can-cache-xl.jmx
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.2">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Can Cache Extra Large Load" enabled="true">
+      <stringProp name="TestPlan.comments">Saturation and capacity planning profile</stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="targetHost" elementType="Argument">
+            <stringProp name="Argument.name">targetHost</stringProp>
+            <stringProp name="Argument.value">${__P(targetHost,127.0.0.1)}</stringProp>
+            <stringProp name="Argument.desc">Hostname of the Can Cache node</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="targetPort" elementType="Argument">
+            <stringProp name="Argument.name">targetPort</stringProp>
+            <stringProp name="Argument.value">${__P(targetPort,11211)}</stringProp>
+            <stringProp name="Argument.desc">Memcached TCP port</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="ttlSeconds" elementType="Argument">
+            <stringProp name="Argument.name">ttlSeconds</stringProp>
+            <stringProp name="Argument.value">${__P(ttlSeconds,60)}</stringProp>
+            <stringProp name="Argument.desc">TTL assigned to SET</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="connectTimeoutMillis" elementType="Argument">
+            <stringProp name="Argument.name">connectTimeoutMillis</stringProp>
+            <stringProp name="Argument.value">${__P(connectTimeoutMillis,1500)}</stringProp>
+            <stringProp name="Argument.desc">Socket connect timeout</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="readTimeoutMillis" elementType="Argument">
+            <stringProp name="Argument.name">readTimeoutMillis</stringProp>
+            <stringProp name="Argument.value">${__P(readTimeoutMillis,4000)}</stringProp>
+            <stringProp name="Argument.desc">Socket read timeout</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="keyPrefix" elementType="Argument">
+            <stringProp name="Argument.name">keyPrefix</stringProp>
+            <stringProp name="Argument.value">${__P(keyPrefix,perf-)}</stringProp>
+            <stringProp name="Argument.desc">Prefix for generated keys</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="payloadSize" elementType="Argument">
+            <stringProp name="Argument.name">payloadSize</stringProp>
+            <stringProp name="Argument.value">${__P(payloadSize,512)}</stringProp>
+            <stringProp name="Argument.desc">Payload size in bytes</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="durationSeconds" elementType="Argument">
+            <stringProp name="Argument.name">durationSeconds</stringProp>
+            <stringProp name="Argument.value">${__P(durationSeconds,900)}</stringProp>
+            <stringProp name="Argument.desc">Thread group duration</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="resultFile" elementType="Argument">
+            <stringProp name="Argument.name">resultFile</stringProp>
+            <stringProp name="Argument.value">${__P(resultFile,results/can-cache-xl.jtl)}</stringProp>
+            <stringProp name="Argument.desc">Results output path</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"/>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Extra Large Load Threads" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loops" enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">-1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">100</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">90</stringProp>
+        <longProp name="ThreadGroup.start_time">0</longProp>
+        <longProp name="ThreadGroup.end_time">0</longProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${durationSeconds}</stringProp>
+        <stringProp name="ThreadGroup.delay">0</stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="Memcached Round Trip" enabled="true">
+          <stringProp name="cacheKey">groovy-memcached-roundtrip</stringProp>
+          <stringProp name="filename"/>
+          <stringProp name="parameters"/>
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="script"><![CDATA[import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.util.UUID
+
+def host = vars.get("targetHost")
+int port = (vars.get("targetPort") ?: "11211") as int
+int ttl = (vars.get("ttlSeconds") ?: "60") as int
+int payloadSize = (vars.get("payloadSize") ?: "512") as int
+int connectTimeout = (vars.get("connectTimeoutMillis") ?: "1500") as int
+int readTimeout = (vars.get("readTimeoutMillis") ?: "4000") as int
+def keyPrefix = vars.get("keyPrefix") ?: "perf-"
+
+Socket socket
+BufferedWriter writer
+BufferedReader reader
+
+SampleResult.sampleStart()
+try {
+    socket = new Socket()
+    socket.connect(new InetSocketAddress(host, port), connectTimeout)
+    socket.soTimeout = readTimeout
+    socket.tcpNoDelay = true
+
+    writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), "UTF-8"))
+    reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), "UTF-8"))
+
+    def random = UUID.randomUUID().toString().replace("-", "")
+    int repeat = Math.max(1, (int) Math.ceil(payloadSize / (double) random.length()))
+    def payloadSource = random * repeat
+    def payload = payloadSource.substring(0, payloadSize)
+    byte[] payloadBytes = payload.getBytes("UTF-8")
+    def key = keyPrefix + random.substring(0, Math.min(16, random.length()))
+
+    writer.write("set ${key} 0 ${ttl} ${payloadBytes.length}\\r\\n")
+    writer.write(payload)
+    writer.write("\\r\\n")
+    writer.flush()
+
+    def setResp = reader.readLine()
+    if (!"STORED".equals(setResp)) {
+        throw new IOException("SET failed with response: ${setResp}")
+    }
+
+    writer.write("get ${key}\\r\\n")
+    writer.flush()
+
+    def header = reader.readLine()
+    if (header == null || !header.startsWith("VALUE")) {
+        throw new IOException("Unexpected GET header: ${header}")
+    }
+
+    def returned = reader.readLine()
+    def trailer = reader.readLine()
+    if (!payload.equals(returned)) {
+        throw new IOException("Returned payload mismatch (${returned?.length()} vs expected ${payload.length()})")
+    }
+    if (!"END".equals(trailer)) {
+        throw new IOException("Missing END after GET, received: ${trailer}")
+    }
+
+    writer.write("delete ${key}\\r\\n")
+    writer.flush()
+    def deleteResp = reader.readLine()
+    if (deleteResp == null || !(deleteResp.equals("DELETED") || deleteResp.equals("NOT_FOUND"))) {
+        throw new IOException("DELETE failed with response: ${deleteResp}")
+    }
+
+    SampleResult.setResponseCodeOK()
+    SampleResult.setResponseMessage("Round trip succeeded")
+    SampleResult.setResponseData(("SET:${setResp};GET:${header};DEL:${deleteResp}").getBytes("UTF-8"))
+    SampleResult.setSuccessful(true)
+} catch (Exception ex) {
+    log.error("Memcached round trip failed", ex)
+    SampleResult.setSuccessful(false)
+    SampleResult.setResponseCode("500")
+    SampleResult.setResponseMessage(ex.getMessage())
+    def sw = new StringWriter()
+    ex.printStackTrace(new PrintWriter(sw))
+    SampleResult.setResponseData(sw.toString(), "UTF-8")
+} finally {
+    SampleResult.sampleEnd()
+    try {
+        writer?.close()
+    } catch (Exception ignore) {}
+    try {
+        reader?.close()
+    } catch (Exception ignore) {}
+    try {
+        socket?.close()
+    } catch (Exception ignore) {}
+}
+]]></stringProp>
+        </JSR223Sampler>
+        <hashTree/>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Think Time" enabled="true">
+          <stringProp name="ConstantTimer.delay">25</stringProp>
+        </ConstantTimer>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">${resultFile}</stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/performance-tests/nfr/large.md
+++ b/performance-tests/nfr/large.md
@@ -1,0 +1,45 @@
+# Large Load NFR (L)
+
+## Objective
+Stress CPU, networking, and TTL eviction logic under heavy concurrent access.
+This profile simulates peak trading or promotion windows where cache throughput
+must remain high without cascading failures or timeouts.
+
+## Workload model
+
+| Parameter | Value |
+| --- | --- |
+| Concurrent users | 50 threads |
+| Ramp-up | 60 seconds |
+| Duration | 600 seconds |
+| Payload | 256 byte values |
+| Think time | 50 ms constant timer |
+| Operations | `set` + `get` + `delete` per iteration |
+
+## Success criteria
+
+* **Availability:** ≥ 99.0% successful samples (≤ 1.0% errors).
+* **Latency:**
+  * Average response time ≤ 55 ms.
+  * 95th percentile response time ≤ 110 ms.
+  * 99th percentile response time ≤ 180 ms.
+* **Resource utilisation:** CPU below 80%, heap usage below 80%, and no more than
+  two full GC cycles during the steady-state phase.
+* **Capacity:** Cache hit ratio remains ≥ 90% assuming working-set residency.
+
+## Observability and reporting
+
+* Persist detailed metrics to `results/can-cache-large.jtl` and capture a copy of
+  JMeter’s console summariser output.
+* Record host-level CPU, memory, and network throughput along with application
+  logs for correlation.
+* Capture Quarkus metrics output (if enabled) or export JMX metrics for offline
+  analysis of evictions, TTL expirations, and replication lag.
+
+## Exit conditions
+
+* Success criteria satisfied for the final 5 minutes of the steady-state window.
+* No replication failures, snapshot write errors, or thread starvation detected
+  in logs or monitoring.
+* System recovers to nominal resource consumption within 2 minutes after the
+  test completes.

--- a/performance-tests/nfr/medium.md
+++ b/performance-tests/nfr/medium.md
@@ -1,0 +1,44 @@
+# Medium Load NFR (M)
+
+## Objective
+Assess the system’s behaviour under moderate, production-like concurrency. The
+medium profile should validate that the node scales predictably and remains
+within latency/error budgets with realistic read/write pressure.
+
+## Workload model
+
+| Parameter | Value |
+| --- | --- |
+| Concurrent users | 20 threads |
+| Ramp-up | 30 seconds |
+| Duration | 300 seconds |
+| Payload | 128 byte values |
+| Think time | 75 ms constant timer |
+| Operations | `set` + `get` + `delete` per iteration |
+
+## Success criteria
+
+* **Availability:** ≥ 99.5% successful samples (≤ 0.5% errors).
+* **Latency:**
+  * Average response time ≤ 35 ms.
+  * 95th percentile response time ≤ 75 ms.
+  * 99th percentile response time ≤ 120 ms.
+* **Resource utilisation:** CPU below 60% and heap usage below 70% with no
+  sustained GC pauses longer than 150 ms.
+
+## Observability and reporting
+
+* Persist detailed results to `results/can-cache-medium.jtl` and capture JMeter
+  summary output.
+* Monitor operating system and JVM metrics (CPU, GC, thread counts, network) for
+  regressions relative to small-load baselines.
+* Record Can Cache metrics (hit rate, eviction counts) if metric reporting is
+  enabled during the run.
+
+## Exit conditions
+
+* All success criteria satisfied for the final 3 minutes of the steady-state
+  period.
+* No WARN/ERROR spikes in the application log beyond transient multicast
+  discovery messages.
+* Cluster membership remains stable with no unexpected node drops.

--- a/performance-tests/nfr/small.md
+++ b/performance-tests/nfr/small.md
@@ -1,0 +1,39 @@
+# Small Load NFR (S)
+
+## Objective
+Validate basic availability and response time of a single Can Cache node under a
+light, smoke-test style workload. This profile ensures the deployment is healthy
+before executing heavier scenarios or promoting changes.
+
+## Workload model
+
+| Parameter | Value |
+| --- | --- |
+| Concurrent users | 5 threads |
+| Ramp-up | 10 seconds |
+| Duration | 120 seconds |
+| Payload | 64 byte values |
+| Think time | 100 ms constant timer |
+| Operations | `set` + `get` + `delete` per iteration |
+
+## Success criteria
+
+* **Availability:** ≥ 99.9% successful samples (no more than 0.1% errors).
+* **Latency:**
+  * Average response time ≤ 25 ms.
+  * 95th percentile response time ≤ 50 ms.
+* **Resource utilisation:** CPU below 40% and heap usage below 60% on the
+  targeted node during the steady-state window.
+
+## Observability and reporting
+
+* Capture CLI output from JMeter’s summariser and persist `results/can-cache-small.jtl`.
+* Track host metrics (CPU, memory, network) via operating system tooling or
+  an external monitor while the test runs.
+* Annotate dashboards with the test identifier `perf-small` for traceability.
+
+## Exit conditions
+
+* All success criteria met for at least the final minute of the run.
+* No critical or high severity errors in the Can Cache server logs.
+* Snapshot and replication subsystems remain operational (no stuck threads).

--- a/performance-tests/nfr/xl.md
+++ b/performance-tests/nfr/xl.md
@@ -1,0 +1,47 @@
+# Extra Large Load NFR (XL)
+
+## Objective
+Characterise saturation behaviour, capacity headroom, and failure handling by
+pushing the cache node to its upper concurrency limit. This test supports
+capacity planning and burn-in exercises prior to high-scale events.
+
+## Workload model
+
+| Parameter | Value |
+| --- | --- |
+| Concurrent users | 100 threads |
+| Ramp-up | 90 seconds |
+| Duration | 900 seconds |
+| Payload | 512 byte values |
+| Think time | 25 ms constant timer |
+| Operations | `set` + `get` + `delete` per iteration |
+
+## Success criteria
+
+* **Availability:** ≥ 98.5% successful samples (≤ 1.5% errors).
+* **Latency:**
+  * Average response time ≤ 80 ms.
+  * 95th percentile response time ≤ 160 ms.
+  * 99th percentile response time ≤ 250 ms.
+* **Resource utilisation:** CPU may peak up to 90% but should avoid sustained
+  pegging (> 30 seconds). Heap usage must stay below 85% with no allocation
+  failures or `OutOfMemoryError`.
+* **Stability:** Application remains reachable, accepts new connections, and
+  continues to replicate data without exceeding 1 second of lag.
+
+## Observability and reporting
+
+* Persist detailed metrics to `results/can-cache-xl.jtl` and retain the console
+  summary output for historical comparison.
+* Capture per-second CPU, memory, GC, and network telemetry. Flag any GC pause
+  longer than 250 ms for investigation.
+* Monitor multicast discovery, replication, and snapshot logs to surface back
+  pressure or retry loops triggered by the high load.
+
+## Exit conditions
+
+* Success criteria satisfied for the final 8 minutes of the run.
+* The system remains responsive and recovers to baseline CPU (< 50%) and heap
+  (< 60%) within 5 minutes of test completion.
+* No data loss or cache corruption detected from spot-checks performed after the
+  test (e.g., manual `get` on recently written keys).


### PR DESCRIPTION
## Summary
- add CLI-ready JMeter plans for small, medium, large, and extra-large cache workloads
- implement a reusable Groovy sampler that exercises set/get/delete cycles with property overrides
- document execution steps and target non-functional requirements for each load tier

## Testing
- not run (configuration-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d1699328688323b4840a8e22b75526