### PR TITLE
Switch integration harness to Java client

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target
+integration-tests/target
+.git
+.gitignore
+.idea
+*.iml
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /workspace/app
+
+COPY pom.xml ./
+COPY mvnw ./
+COPY .mvn .mvn
+RUN chmod +x mvnw
+RUN ./mvnw -B dependency:go-offline
+
+COPY src ./src
+RUN ./mvnw -B package -DskipTests
+
+FROM eclipse-temurin:21-jre
+WORKDIR /opt/can-cache
+COPY --from=build /workspace/app/target/quarkus-app/ ./quarkus-app/
+
+EXPOSE 11211
+ENTRYPOINT ["java", "-jar", "/opt/can-cache/quarkus-app/quarkus-run.jar"]

--- a/README.md
+++ b/README.md
@@ -218,6 +218,21 @@ flowchart TD
 Proje yalnızca Quarkus Arc (CDI) ve JUnit 5 (test) bağımlılıklarını kullanır; ek
 framework’ler olmadan saf TCP ve koleksiyon API’leri ile çalışır.【F:pom.xml†L23-L43】
 
+## Entegrasyon testlerini çalıştırma
+
+Uygulamanın Memcached metin protokolünü uçtan uca doğrulayan bir entegrasyon
+testi paketi bulunmaktadır. Testler, uygulamayı Docker imajı olarak derler,
+`docker compose` ile ayağa kaldırır ve memcached komutlarının tüm kritik
+senaryolarını Java ile yazılmış bir JUnit koşucu üzerinden dener.
+
+```
+./scripts/run-integration-tests.sh
+```
+
+Komut, gerekli Docker imajlarını derledikten sonra test konteynerini çalıştırır
+ve başarısızlık durumunda uygun çıkış kodunu döndürür. CI/CD süreçlerine dahil
+ederken aynı komut çağrılabilir.
+
 ## Proje girişi
 
 Quarkus uygulaması `CanCacheApplication` üzerinden başlar ve `Quarkus.run`

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+
+services:
+  can-cache:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: can-cache:integration
+    ports:
+      - "11211:11211"
+  integration-tests:
+    build:
+      context: integration-tests
+    depends_on:
+      - can-cache
+    environment:
+      CAN_CACHE_HOST: can-cache
+      CAN_CACHE_PORT: "11211"
+    command: ["mvn", "-B", "test"]

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.9-eclipse-temurin-21
+
+WORKDIR /workspace/tests
+
+COPY pom.xml ./
+RUN mvn -B dependency:go-offline
+
+COPY src ./src
+
+CMD ["mvn", "-B", "test"]

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.can</groupId>
+    <artifactId>can-cache-integration-tests</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/src/test/java/com/can/cache/integration/MemcacheTextClient.java
+++ b/integration-tests/src/test/java/com/can/cache/integration/MemcacheTextClient.java
@@ -1,0 +1,303 @@
+package com.can.cache.integration;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Minimal memcached text protocol client implemented in Java so that the
+ * integration tests can exercise the can-cache service end to end without
+ * relying on external libraries.
+ */
+public class MemcacheTextClient implements AutoCloseable {
+
+    public static final String DEFAULT_HOST = System.getenv().getOrDefault("CAN_CACHE_HOST", "127.0.0.1");
+    public static final int DEFAULT_PORT = Integer.parseInt(System.getenv().getOrDefault("CAN_CACHE_PORT", "11211"));
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+    private final String host;
+    private final int port;
+    private final Duration timeout;
+
+    private Socket socket;
+    private BufferedInputStream input;
+    private BufferedOutputStream output;
+
+    public MemcacheTextClient() {
+        this(DEFAULT_HOST, DEFAULT_PORT, DEFAULT_TIMEOUT);
+    }
+
+    public MemcacheTextClient(String host, int port, Duration timeout) {
+        this.host = host;
+        this.port = port;
+        this.timeout = timeout;
+    }
+
+    public void connect() throws IOException {
+        if (socket != null) {
+            return;
+        }
+        socket = new Socket();
+        socket.connect(new InetSocketAddress(host, port), (int) timeout.toMillis());
+        socket.setSoTimeout((int) timeout.toMillis());
+        input = new BufferedInputStream(socket.getInputStream());
+        output = new BufferedOutputStream(socket.getOutputStream());
+    }
+
+    private void ensureConnected() {
+        if (socket == null || !socket.isConnected()) {
+            throw new IllegalStateException("Client is not connected");
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (input != null) {
+                input.close();
+            }
+        } catch (IOException ignored) {
+            // Ignore close errors in tear down paths.
+        }
+        try {
+            if (output != null) {
+                output.close();
+            }
+        } catch (IOException ignored) {
+            // Ignore close errors in tear down paths.
+        }
+        try {
+            if (socket != null) {
+                socket.close();
+            }
+        } catch (IOException ignored) {
+            // Ignore close errors in tear down paths.
+        }
+        input = null;
+        output = null;
+        socket = null;
+    }
+
+    private void sendLine(String line) throws IOException {
+        ensureConnected();
+        byte[] data = (line + "\r\n").getBytes(StandardCharsets.UTF_8);
+        output.write(data);
+        output.flush();
+    }
+
+    private void sendDataBlock(byte[] payload) throws IOException {
+        ensureConnected();
+        output.write(payload);
+        output.write('\r');
+        output.write('\n');
+        output.flush();
+    }
+
+    private String readLine() throws IOException {
+        ensureConnected();
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        while (true) {
+            int b = input.read();
+            if (b == -1) {
+                throw new EOFException("Connection closed by server");
+            }
+            if (b == '\r') {
+                int next = input.read();
+                if (next != '\n') {
+                    throw new IOException("Protocol violation: expected LF after CR");
+                }
+                break;
+            }
+            if (b == '\n') {
+                break;
+            }
+            buffer.write(b);
+        }
+        return buffer.toString(StandardCharsets.UTF_8);
+    }
+
+    private byte[] readExact(int length) throws IOException {
+        ensureConnected();
+        byte[] data = input.readNBytes(length);
+        if (data.length != length) {
+            throw new EOFException("Unexpected end of stream");
+        }
+        int cr = input.read();
+        int lf = input.read();
+        if (cr != '\r' || lf != '\n') {
+            throw new IOException("Protocol violation: missing CRLF after data block");
+        }
+        return data;
+    }
+
+    public String storageCommand(String verb, String key, String value, int flags, int exptime) throws IOException {
+        return storageCommand(verb, key, value, flags, exptime, false);
+    }
+
+    public String storageCommand(String verb, String key, String value, int flags, int exptime, boolean noreply) throws IOException {
+        byte[] payload = value.getBytes(StandardCharsets.UTF_8);
+        StringBuilder builder = new StringBuilder();
+        builder.append(verb)
+            .append(' ').append(key)
+            .append(' ').append(flags)
+            .append(' ').append(exptime)
+            .append(' ').append(payload.length);
+        if (noreply) {
+            builder.append(" noreply");
+        }
+        sendLine(builder.toString());
+        sendDataBlock(payload);
+        if (noreply) {
+            return "";
+        }
+        return readLine();
+    }
+
+    public String set(String key, String value, int flags, int exptime) throws IOException {
+        return storageCommand("set", key, value, flags, exptime);
+    }
+
+    public String add(String key, String value, int flags, int exptime) throws IOException {
+        return storageCommand("add", key, value, flags, exptime);
+    }
+
+    public String replace(String key, String value, int flags, int exptime) throws IOException {
+        return storageCommand("replace", key, value, flags, exptime);
+    }
+
+    public String append(String key, String value) throws IOException {
+        return storageCommand("append", key, value, 0, 0);
+    }
+
+    public String prepend(String key, String value) throws IOException {
+        return storageCommand("prepend", key, value, 0, 0);
+    }
+
+    public String cas(String key, String value, long casToken, int flags, int exptime) throws IOException {
+        byte[] payload = value.getBytes(StandardCharsets.UTF_8);
+        String command = String.format("cas %s %d %d %d %d", key, flags, exptime, payload.length, casToken);
+        sendLine(command);
+        sendDataBlock(payload);
+        return readLine();
+    }
+
+    public String delete(String key) throws IOException {
+        sendLine("delete " + key);
+        return readLine();
+    }
+
+    public Long incr(String key, long delta) throws IOException {
+        sendLine("incr " + key + " " + delta);
+        return parseNumericResponse(readLine());
+    }
+
+    public Long decr(String key, long delta) throws IOException {
+        sendLine("decr " + key + " " + delta);
+        return parseNumericResponse(readLine());
+    }
+
+    private Long parseNumericResponse(String response) {
+        for (int i = 0; i < response.length(); i++) {
+            if (!Character.isDigit(response.charAt(i))) {
+                return null;
+            }
+        }
+        if (response.isEmpty()) {
+            return null;
+        }
+        return Long.parseLong(response);
+    }
+
+    public String touch(String key, int exptime) throws IOException {
+        sendLine("touch " + key + " " + exptime);
+        return readLine();
+    }
+
+    public String flushAll() throws IOException {
+        sendLine("flush_all");
+        return readLine();
+    }
+
+    public Map<String, String> stats() throws IOException {
+        sendLine("stats");
+        Map<String, String> stats = new LinkedHashMap<>();
+        while (true) {
+            String line = readLine();
+            if ("END".equals(line)) {
+                return stats;
+            }
+            String[] parts = line.split(" ", 3);
+            if (parts.length == 3 && "STAT".equals(parts[0])) {
+                stats.put(parts[1], parts[2]);
+            }
+        }
+    }
+
+    public String version() throws IOException {
+        sendLine("version");
+        return readLine();
+    }
+
+    public Map<String, ValueRecord> get(String... keys) throws IOException {
+        return getMany("get", keys);
+    }
+
+    public Map<String, ValueRecord> gets(String... keys) throws IOException {
+        return getMany("gets", keys);
+    }
+
+    private Map<String, ValueRecord> getMany(String command, String... keys) throws IOException {
+        if (keys.length == 0) {
+            return Map.of();
+        }
+        String joinedKeys = String.join(" ", keys);
+        sendLine(command + " " + joinedKeys);
+        Map<String, ValueRecord> results = new LinkedHashMap<>();
+        while (true) {
+            String line = readLine();
+            if ("END".equals(line)) {
+                return results;
+            }
+            String[] parts = line.split(" ");
+            if (parts.length < 4 || !"VALUE".equals(parts[0])) {
+                throw new IOException("Unexpected response: " + line);
+            }
+            String key = parts[1];
+            int flags = Integer.parseInt(parts[2]);
+            int length = Integer.parseInt(parts[3]);
+            Long cas = parts.length >= 5 ? Long.parseLong(parts[4]) : null;
+            byte[] data = readExact(length);
+            String value = new String(data, StandardCharsets.UTF_8);
+            results.put(key, new ValueRecord(key, flags, value, cas));
+        }
+    }
+
+    public static void waitForService(Duration timeout) throws InterruptedException {
+        waitForService(DEFAULT_HOST, DEFAULT_PORT, timeout);
+    }
+
+    public static void waitForService(String host, int port, Duration timeout) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        Duration connectTimeout = Duration.ofSeconds(1);
+        while (System.nanoTime() < deadline) {
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(host, port), (int) connectTimeout.toMillis());
+                return;
+            } catch (IOException ex) {
+                Thread.sleep(500);
+            }
+        }
+        throw new IllegalStateException("Service " + host + ":" + port + " did not become ready within " + timeout);
+    }
+
+    public record ValueRecord(String key, int flags, String value, Long casToken) {
+    }
+}

--- a/integration-tests/src/test/java/com/can/cache/integration/MemcachedProtocolTest.java
+++ b/integration-tests/src/test/java/com/can/cache/integration/MemcachedProtocolTest.java
@@ -1,0 +1,144 @@
+package com.can.cache.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MemcachedProtocolTest {
+
+    private MemcacheTextClient client;
+
+    @BeforeAll
+    static void waitForService() throws Exception {
+        MemcacheTextClient.waitForService(Duration.ofSeconds(30));
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        client = new MemcacheTextClient();
+        client.connect();
+        client.flushAll();
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            client.flushAll();
+        } catch (IOException ignored) {
+            // Ignore cleanup failures if the server terminated mid-test.
+        }
+        client.close();
+    }
+
+    @Test
+    void setAndGetRoundTrip() throws IOException {
+        assertEquals("STORED", client.set("alpha", "payload", 7, 0));
+
+        Map<String, MemcacheTextClient.ValueRecord> values = client.get("alpha");
+        MemcacheTextClient.ValueRecord record = values.get("alpha");
+        assertNotNull(record);
+        assertEquals(7, record.flags());
+        assertEquals("payload", record.value());
+    }
+
+    @Test
+    void addReplaceAppendAndPrepend() throws IOException {
+        assertEquals("STORED", client.add("greeting", "Hello", 0, 0));
+        assertEquals("NOT_STORED", client.add("greeting", "Ignored", 0, 0));
+        assertEquals("STORED", client.replace("greeting", "World", 0, 0));
+        assertEquals("NOT_STORED", client.replace("missing", "nope", 0, 0));
+        assertEquals("STORED", client.append("greeting", "!"));
+        assertEquals("STORED", client.prepend("greeting", "Say:"));
+
+        String value = client.get("greeting").get("greeting").value();
+        assertEquals("Say:World!", value);
+    }
+
+    @Test
+    void deleteClearsExistingValues() throws IOException {
+        assertEquals("STORED", client.set("tmp", "1", 0, 0));
+        assertEquals("DELETED", client.delete("tmp"));
+        assertTrue(client.get("tmp").isEmpty());
+        assertEquals("NOT_FOUND", client.delete("tmp"));
+    }
+
+    @Test
+    void casFlowDetectsWriteConflicts() throws IOException {
+        assertEquals("STORED", client.set("item", "first", 0, 0));
+        MemcacheTextClient.ValueRecord initial = client.gets("item").get("item");
+        assertNotNull(initial);
+        Long casToken = initial.casToken();
+        assertNotNull(casToken);
+
+        assertEquals("STORED", client.cas("item", "second", casToken, 0, 0));
+
+        String staleResult = client.cas("item", "third", casToken, 0, 0);
+        assertEquals("EXISTS", staleResult);
+
+        String latest = client.get("item").get("item").value();
+        assertEquals("second", latest);
+    }
+
+    @Test
+    void incrAndDecrFollowMemcachedSemantics() throws IOException {
+        assertEquals("STORED", client.set("counter", "10", 0, 0));
+        assertEquals(15L, client.incr("counter", 5));
+        assertEquals(12L, client.decr("counter", 3));
+        assertEquals(0L, client.decr("counter", 50));
+        assertNull(client.incr("missing", 1));
+        assertNull(client.decr("missing", 1));
+    }
+
+    @Test
+    void touchAndExpiration() throws Exception {
+        assertEquals("STORED", client.set("ephemeral", "data", 0, 1));
+        Thread.sleep(600);
+        assertEquals("TOUCHED", client.touch("ephemeral", 2));
+        assertTrue(client.get("ephemeral").containsKey("ephemeral"));
+        Thread.sleep(1100);
+        assertTrue(client.get("ephemeral").containsKey("ephemeral"));
+        Thread.sleep(1200);
+        assertTrue(client.get("ephemeral").isEmpty());
+        assertEquals("NOT_FOUND", client.touch("missing", 5));
+    }
+
+    @Test
+    void flushAllInvalidatesEverything() throws IOException {
+        assertEquals("STORED", client.set("k1", "v1", 0, 0));
+        assertEquals("STORED", client.set("k2", "v2", 0, 0));
+        assertEquals("OK", client.flushAll());
+        assertTrue(client.get("k1").isEmpty());
+        assertTrue(client.get("k2").isEmpty());
+    }
+
+    @Test
+    void multiGetReturnsAllKeys() throws IOException {
+        assertEquals("STORED", client.set("a", "1", 0, 0));
+        assertEquals("STORED", client.set("b", "2", 0, 0));
+        Map<String, MemcacheTextClient.ValueRecord> results = client.get("a", "b", "missing");
+        assertEquals("1", results.get("a").value());
+        assertEquals("2", results.get("b").value());
+        assertFalse(results.containsKey("missing"));
+    }
+
+    @Test
+    void statsAndVersionCommands() throws IOException {
+        Map<String, String> stats = client.stats();
+        assertTrue(stats.containsKey("curr_items"));
+        assertTrue(stats.containsKey("cmd_get"));
+
+        String version = client.version();
+        assertTrue(version.startsWith("VERSION"));
+    }
+}

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.integration.yml"
+
+cleanup() {
+  docker compose -f "$COMPOSE_FILE" down --remove-orphans -v >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+docker compose -f "$COMPOSE_FILE" build
+
+docker compose -f "$COMPOSE_FILE" up --abort-on-container-exit --exit-code-from integration-tests


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile and docker compose definition to run can-cache inside containers
- provide a Java-based integration test harness that validates memcached protocol scenarios end to end
- document the dockerized integration workflow and wrapper script for future CI/CD usage

## Testing
- `./mvnw test` *(fails: Maven wrapper cannot download dependencies because external network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d169191e24832394b78578ce4ffa49