### PR TITLE
Fix SnapshotScheduler CDI bean definition

### DIFF
--- a/src/main/java/com/can/rdb/SnapshotScheduler.java
+++ b/src/main/java/com/can/rdb/SnapshotScheduler.java
@@ -23,22 +23,22 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 @Startup
 @Singleton
-public class SnapshotScheduler<K, V> implements AutoCloseable {
+public class SnapshotScheduler implements AutoCloseable {
 
     private static final Logger LOG = Logger.getLogger(SnapshotScheduler.class);
 
-    private final CacheEngine<K, V> engine;
-    private final SnapshotFile<K, V> snapshotFile;
+    private final CacheEngine<String, String> engine;
+    private final SnapshotFile<String, String> snapshotFile;
     private final long intervalSeconds;
     private final AtomicBoolean started = new AtomicBoolean(false);
     private ScheduledExecutorService executor;
 
     @Inject
-    public SnapshotScheduler(CacheEngine<K, V> engine, SnapshotFile<K, V> snapshotFile, AppProperties properties) {
+    public SnapshotScheduler(CacheEngine<String, String> engine, SnapshotFile<String, String> snapshotFile, AppProperties properties) {
         this(engine, snapshotFile, properties.rdb().snapshotIntervalSeconds());
     }
 
-    public SnapshotScheduler(CacheEngine<K, V> engine, SnapshotFile<K, V> snapshotFile, long intervalSeconds) {
+    public SnapshotScheduler(CacheEngine<String, String> engine, SnapshotFile<String, String> snapshotFile, long intervalSeconds) {
         this.engine = engine;
         this.snapshotFile = snapshotFile;
         this.intervalSeconds = intervalSeconds;

--- a/src/test/java/com/can/config/LifecycleManagedBeansTest.java
+++ b/src/test/java/com/can/config/LifecycleManagedBeansTest.java
@@ -17,7 +17,7 @@ class LifecycleManagedBeansTest {
     MetricsReporter reporter;
 
     @Inject
-    SnapshotScheduler<String, String> scheduler;
+    SnapshotScheduler scheduler;
 
     @Inject
     Broker broker;

--- a/src/test/java/com/can/rdb/SnapshotComponentsTest.java
+++ b/src/test/java/com/can/rdb/SnapshotComponentsTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class SnapshotComponentsTest {
 
     private CacheEngine<String, String> engine;
-    private SnapshotScheduler<String, String> scheduler;
+    private SnapshotScheduler scheduler;
 
     @AfterEach
     void tearDown() throws Exception {
@@ -83,7 +83,7 @@ class SnapshotComponentsTest {
                     .build();
             engine.set("key", "value");
 
-            scheduler = new SnapshotScheduler<>(engine, snapshot, 0);
+            scheduler = new SnapshotScheduler(engine, snapshot, 0);
             scheduler.start();
 
             Thread.sleep(200);


### PR DESCRIPTION
## Summary
- update `SnapshotScheduler` to use the concrete cache types so it can be created as a CDI singleton
- adjust tests to reference the non-generic scheduler implementation

## Testing
- mvn test *(fails: Unable to resolve Maven dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d195bd4a7c8323af042e6e3a6e1024