### PR TITLE
Handle optional node id configuration

### DIFF
--- a/src/main/java/com/can/config/AppConfig.java
+++ b/src/main/java/com/can/config/AppConfig.java
@@ -92,17 +92,18 @@ public class AppConfig {
     public Node<String, String> localNode(CacheEngine<String, String> engine) {
         var discovery = properties.cluster().discovery();
         var replication = properties.cluster().replication();
-        String nodeId = discovery.nodeId();
-        if (nodeId == null || nodeId.isBlank()) {
-            String host = replication.advertiseHost();
-            if (host == null || host.isBlank() || "0.0.0.0".equals(host)) {
-                host = replication.bindHost();
-            }
-            if (host == null || host.isBlank() || "0.0.0.0".equals(host)) {
-                host = "127.0.0.1";
-            }
-            nodeId = host + ":" + replication.port();
-        }
+        String nodeId = discovery.nodeId()
+                .filter(id -> !id.isBlank())
+                .orElseGet(() -> {
+                    String host = replication.advertiseHost();
+                    if (host == null || host.isBlank() || "0.0.0.0".equals(host)) {
+                        host = replication.bindHost();
+                    }
+                    if (host == null || host.isBlank() || "0.0.0.0".equals(host)) {
+                        host = "127.0.0.1";
+                    }
+                    return host + ":" + replication.port();
+                });
         final String resolvedId = nodeId;
         return new Node<>() {
             @Override

--- a/src/main/java/com/can/config/AppProperties.java
+++ b/src/main/java/com/can/config/AppProperties.java
@@ -3,6 +3,8 @@ package com.can.config;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
+import java.util.Optional;
+
 /**
  * Uygulama yapılandırma değerlerini tip güvenli bir şekilde okumak için kullanılan
  * konfigürasyon arayüzüdür. Alt arayüzler metrik raporlama sıklığı, RDB anlık
@@ -72,8 +74,7 @@ public interface AppProperties
         @WithDefault("15000")
         long failureTimeoutMillis();
 
-        @WithDefault("")
-        String nodeId();
+        Optional<String> nodeId();
     }
 
     interface Replication {

--- a/src/test/java/com/can/cluster/coordination/ReplicationProtocolTest.java
+++ b/src/test/java/com/can/cluster/coordination/ReplicationProtocolTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.time.Duration;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -185,7 +186,7 @@ class ReplicationProtocolTest
         public long failureTimeoutMillis() { return 6000; }
 
         @Override
-        public String nodeId() { return "test-node"; }
+        public Optional<String> nodeId() { return Optional.of("test-node"); }
     }
 
     private static final class TestReplication implements AppProperties.Replication {


### PR DESCRIPTION
## Summary
- allow the discovery node id configuration to be absent by exposing it as an Optional
- derive the local node id from advertised/bind host when the property is missing or blank
- update the replication protocol test stub to the new Optional-based signature

## Testing
- mvn test *(fails: unable to resolve Quarkus dependencies because the Maven Central endpoint is unreachable from the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19718a35c8323aa055edced5779ae