### PR TITLE
Add extensive unit tests

### DIFF
--- a/src/test/java/com/can/cluster/ClusterClientTest.java
+++ b/src/test/java/com/can/cluster/ClusterClientTest.java
@@ -1,0 +1,180 @@
+package com.can.cluster;
+
+import com.can.codec.StringCodec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClusterClientTest
+{
+    private ConsistentHashRing<Node<String, String>> ring;
+    private TestNode node1;
+    private TestNode node2;
+    private ClusterClient<String, String> client;
+
+    @BeforeEach
+    void setup()
+    {
+        ring = new ConsistentHashRing<>(bytes -> Arrays.hashCode(bytes), 3);
+        node1 = new TestNode("node1");
+        node2 = new TestNode("node2");
+        ring.addNode(node1, node1.id().getBytes());
+        ring.addNode(node2, node2.id().getBytes());
+        client = new ClusterClient<>(ring, 2, StringCodec.UTF8);
+    }
+
+    @Nested
+    class SetGetBehaviour
+    {
+        @Test
+        void set_writes_to_all_replicas()
+        {
+            assertTrue(client.set("key", "value", Duration.ofSeconds(1)));
+            assertEquals("value", node1.get("key"));
+            assertEquals("value", node2.get("key"));
+        }
+
+        @Test
+        void get_returns_first_available_value()
+        {
+            node1.set("key", "value", null);
+            assertEquals("value", client.get("key"));
+        }
+    }
+
+    @Nested
+    class DeleteBehaviour
+    {
+        @Test
+        void delete_returns_true_when_any_node_removes()
+        {
+            client.set("key", "value", null);
+            assertTrue(client.delete("key"));
+            assertNull(node1.get("key"));
+        }
+    }
+
+    @Nested
+    class CasBehaviour
+    {
+        @Test
+        void compare_and_swap_requires_all_success()
+        {
+            client.set("key", "value", null);
+            long expected = node1.cas("key");
+            assertTrue(client.compareAndSwap("key", "new", expected, null));
+            assertEquals("new", node1.get("key"));
+            assertEquals("new", node2.get("key"));
+        }
+
+        @Test
+        void compare_and_swap_fails_when_any_node_fails()
+        {
+            client.set("key", "value", null);
+            node2.forceCas("key", 999L);
+            long expected = node1.cas("key");
+            assertFalse(client.compareAndSwap("key", "new", expected, null));
+            assertEquals("value", node1.get("key"));
+        }
+    }
+
+    @Nested
+    class ClearBehaviour
+    {
+        @Test
+        void clear_invokes_all_nodes()
+        {
+            client.set("a", "1", null);
+            client.set("b", "2", null);
+            client.clear();
+
+            assertTrue(node1.isEmpty());
+            assertTrue(node2.isEmpty());
+        }
+    }
+
+    private static final class TestNode implements Node<String, String>
+    {
+        private final String id;
+        private final Map<String, Entry> store = new ConcurrentHashMap<>();
+        private long casCounter;
+
+        private TestNode(String id)
+        {
+            this.id = id;
+        }
+
+        @Override
+        public boolean set(String key, String value, Duration ttl)
+        {
+            store.put(key, new Entry(value, ++casCounter));
+            return true;
+        }
+
+        @Override
+        public String get(String key)
+        {
+            Entry entry = store.get(key);
+            return entry == null ? null : entry.value;
+        }
+
+        @Override
+        public boolean delete(String key)
+        {
+            return store.remove(key) != null;
+        }
+
+        @Override
+        public boolean compareAndSwap(String key, String value, long expectedCas, Duration ttl)
+        {
+            Entry entry = store.get(key);
+            if (entry == null || entry.cas != expectedCas)
+            {
+                return false;
+            }
+            store.put(key, new Entry(value, ++casCounter));
+            return true;
+        }
+
+        @Override
+        public void clear()
+        {
+            store.clear();
+        }
+
+        @Override
+        public String id()
+        {
+            return id;
+        }
+
+        long cas(String key)
+        {
+            Entry entry = store.get(key);
+            return entry == null ? 0L : entry.cas;
+        }
+
+        void forceCas(String key, long cas)
+        {
+            Entry entry = store.get(key);
+            if (entry != null)
+            {
+                store.put(key, new Entry(entry.value, cas));
+            }
+        }
+
+        boolean isEmpty()
+        {
+            return store.isEmpty();
+        }
+
+        private record Entry(String value, long cas) {}
+    }
+}

--- a/src/test/java/com/can/cluster/ConsistentHashRingTest.java
+++ b/src/test/java/com/can/cluster/ConsistentHashRingTest.java
@@ -1,0 +1,74 @@
+package com.can.cluster;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConsistentHashRingTest
+{
+    private ConsistentHashRing<String> ring;
+
+    @BeforeEach
+    void setup()
+    {
+        ring = new ConsistentHashRing<>(bytes -> Arrays.hashCode(bytes), 4);
+    }
+
+    @Nested
+    class NodeManagement
+    {
+        @Test
+        void add_node_registers_unique_entries()
+        {
+            ring.addNode("n1", "n1".getBytes());
+            ring.addNode("n2", "n2".getBytes());
+
+            List<String> nodes = ring.nodes();
+            assertTrue(nodes.contains("n1"));
+            assertTrue(nodes.contains("n2"));
+        }
+
+        @Test
+        void remove_node_removes_virtual_nodes()
+        {
+            ring.addNode("n1", "n1".getBytes());
+            ring.addNode("n2", "n2".getBytes());
+
+            ring.removeNode("n1", "n1".getBytes());
+            List<String> nodes = ring.nodes();
+            assertFalse(nodes.contains("n1"));
+        }
+    }
+
+    @Nested
+    class ReplicaSelection
+    {
+        @Test
+        void get_replicas_returns_requested_number()
+        {
+            ring.addNode("n1", "n1".getBytes());
+            ring.addNode("n2", "n2".getBytes());
+            ring.addNode("n3", "n3".getBytes());
+
+            List<String> replicas = ring.getReplicas("key".getBytes(), 2);
+            assertEquals(2, replicas.size());
+        }
+
+        @Test
+        void get_replicas_wraps_around_ring()
+        {
+            ring.addNode("n1", "n1".getBytes());
+            ring.addNode("n2", "n2".getBytes());
+
+            List<String> replicas = ring.getReplicas("key".getBytes(), 5);
+            assertTrue(replicas.size() <= 2);
+            assertTrue(replicas.contains("n1"));
+            assertTrue(replicas.contains("n2"));
+        }
+    }
+}

--- a/src/test/java/com/can/codec/CodecsTest.java
+++ b/src/test/java/com/can/codec/CodecsTest.java
@@ -1,0 +1,61 @@
+package com.can.codec;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CodecsTest
+{
+    @Nested
+    class StringCodecBehaviour
+    {
+        @Test
+        void encode_and_decode_roundtrip()
+        {
+            StringCodec codec = StringCodec.UTF8;
+            byte[] encoded = codec.encode("hello");
+            assertEquals("hello", codec.decode(encoded));
+        }
+
+        @Test
+        void encode_and_decode_handles_null()
+        {
+            StringCodec codec = StringCodec.UTF8;
+            assertArrayEquals(new byte[0], codec.encode(null));
+            assertNull(codec.decode(new byte[0]));
+        }
+    }
+
+    @Nested
+    class JavaSerializerCodecBehaviour
+    {
+        @Test
+        void encode_and_decode_serializable_object()
+        {
+            JavaSerializerCodec<Dummy> codec = new JavaSerializerCodec<>();
+            Dummy original = new Dummy("value", 42);
+            byte[] encoded = codec.encode(original);
+            Dummy decoded = codec.decode(encoded);
+
+            assertEquals(original.name, decoded.name);
+            assertEquals(original.count, decoded.count);
+        }
+
+        @Test
+        void decode_returns_null_for_empty_array()
+        {
+            JavaSerializerCodec<Dummy> codec = new JavaSerializerCodec<>();
+            assertNull(codec.decode(new byte[0]));
+        }
+    }
+
+    private record Dummy(String name, int count) implements Serializable
+    {
+        @Serial
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/src/test/java/com/can/core/CacheEngineTest.java
+++ b/src/test/java/com/can/core/CacheEngineTest.java
@@ -1,0 +1,237 @@
+package com.can.core;
+
+import com.can.codec.StringCodec;
+import com.can.metric.MetricsRegistry;
+import com.can.metric.Timer;
+import com.can.pubsub.Broker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CacheEngineTest
+{
+    private CacheEngine<String, String> engine;
+    private MetricsRegistry metrics;
+    private RecordingBroker broker;
+
+    @BeforeEach
+    void setup()
+    {
+        metrics = new MetricsRegistry();
+        broker = new RecordingBroker();
+        engine = CacheEngine.<String, String>builder(StringCodec.UTF8, StringCodec.UTF8)
+                .segments(2)
+                .maxCapacity(8)
+                .cleanerPollMillis(5)
+                .metrics(metrics)
+                .broker(broker)
+                .build();
+    }
+
+    @AfterEach
+    void cleanup()
+    {
+        engine.close();
+    }
+
+    @Nested
+    class SetGetOperations
+    {
+        @Test
+        void set_and_get_roundtrip_updates_metrics()
+        {
+            assertTrue(engine.set("key", "value"));
+            assertEquals("value", engine.get("key"));
+
+            assertEquals(1L, metrics.counter("cache_hits").get());
+            Timer.Sample sample = metrics.timer("cache_get").snapshot();
+            assertEquals("cache_get", sample.name());
+            assertTrue(sample.count() > 0);
+            assertTrue(broker.events().contains("keyspace:set:key"));
+        }
+
+        @Test
+        void delete_removes_entry_and_records_timer()
+        {
+            engine.set("key", "value");
+            assertTrue(engine.delete("key"));
+            assertFalse(engine.exists("key"));
+
+            Timer.Sample sample = metrics.timer("cache_del").snapshot();
+            assertEquals("cache_del", sample.name());
+            assertTrue(sample.count() > 0);
+            assertTrue(broker.events().contains("keyspace:del:key"));
+        }
+
+        @Test
+        void get_with_expired_value_triggers_miss_and_delete() throws InterruptedException
+        {
+            assertTrue(engine.set("key", "value", Duration.ofMillis(10)));
+            Thread.sleep(40);
+
+            assertNull(engine.get("key"));
+            assertFalse(engine.exists("key"));
+            assertTrue(metrics.counter("cache_misses").get() > 0);
+        }
+    }
+
+    @Nested
+    class CasOperations
+    {
+        @Test
+        void compare_and_swap_updates_value_and_ttl() throws InterruptedException
+        {
+            StoredValueCodec.StoredValue base = new StoredValueCodec.StoredValue("v1".getBytes(StandardCharsets.UTF_8), 1, 7L, 0L);
+            String encoded = StoredValueCodec.encode(base);
+            engine.set("key", encoded);
+
+            StoredValueCodec.StoredValue updated = base.withValue("v2".getBytes(StandardCharsets.UTF_8), 9L);
+            String next = StoredValueCodec.encode(updated);
+
+            assertTrue(engine.compareAndSwap("key", next, 7L, Duration.ofMillis(30)));
+            assertEquals(next, engine.get("key"));
+            assertTrue(engine.exists("key"));
+            Thread.sleep(60);
+            assertFalse(engine.exists("key"));
+            assertTrue(broker.events().stream().anyMatch(e -> e.startsWith("keyspace:set:key")));
+        }
+
+        @Test
+        void compare_and_swap_rejects_when_cas_mismatch()
+        {
+            StoredValueCodec.StoredValue base = new StoredValueCodec.StoredValue("v1".getBytes(StandardCharsets.UTF_8), 1, 7L, 0L);
+            engine.set("key", StoredValueCodec.encode(base));
+
+            assertFalse(engine.compareAndSwap("key", "ignored", 1L, null));
+            assertEquals(StoredValueCodec.encode(base), engine.get("key"));
+        }
+    }
+
+    @Nested
+    class ReplayOperations
+    {
+        @Test
+        void replay_set_restores_entry()
+        {
+            byte[] op = new byte[]{'S'};
+            engine.replay(op, StringCodec.UTF8.encode("key"), StringCodec.UTF8.encode("value"), 0L);
+
+            assertEquals("value", engine.get("key"));
+        }
+
+        @Test
+        void replay_delete_removes_entry()
+        {
+            engine.set("key", "value");
+            byte[] op = new byte[]{'D'};
+            engine.replay(op, StringCodec.UTF8.encode("key"), new byte[0], 0L);
+
+            assertNull(engine.get("key"));
+        }
+
+        @Test
+        void replay_skips_expired_entry()
+        {
+            byte[] op = new byte[]{'S'};
+            engine.replay(op, StringCodec.UTF8.encode("key"), StringCodec.UTF8.encode("value"), System.currentTimeMillis() - 1000);
+
+            assertNull(engine.get("key"));
+        }
+    }
+
+    @Nested
+    class ListenerOperations
+    {
+        @Test
+        void on_removal_invoked_for_manual_delete()
+        {
+            engine.set("key", "value");
+            List<String> removed = new ArrayList<>();
+            AutoCloseable handle = engine.onRemoval(removed::add);
+
+            assertTrue(engine.delete("key"));
+            assertEquals(List.of("key"), removed);
+
+            assertDoesNotThrow(() -> handle.close());
+        }
+
+        @Test
+        void on_removal_invoked_for_ttl_expiration() throws InterruptedException
+        {
+            List<String> removed = new ArrayList<>();
+            engine.onRemoval(removed::add);
+            engine.set("key", "value", Duration.ofMillis(10));
+            Thread.sleep(60);
+
+            assertTrue(removed.contains("key"));
+        }
+    }
+
+    @Nested
+    class IterationOperations
+    {
+        @Test
+        void for_each_entry_skips_expired_values()
+        {
+            engine.set("keep", "value");
+            engine.set("expire", "soon", Duration.ofMillis(10));
+            List<String> keys = new ArrayList<>();
+            engine.forEachEntry((key, value, expireAt) -> keys.add(key));
+
+            assertTrue(keys.contains("keep"));
+            assertTrue(keys.contains("expire"));
+
+            // Wait and ensure expired entry is no longer provided
+            try
+            {
+                Thread.sleep(40);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+            }
+            keys.clear();
+            engine.forEachEntry((key, value, expireAt) -> keys.add(key));
+            assertEquals(List.of("keep"), keys);
+        }
+
+        @Test
+        void clear_resets_all_segments()
+        {
+            engine.set("a", "1");
+            engine.set("b", "2");
+            engine.clear();
+
+            assertEquals(0, engine.size());
+            List<String> keys = new ArrayList<>();
+            engine.forEachEntry((key, value, expireAt) -> keys.add(key));
+            assertTrue(keys.isEmpty());
+        }
+    }
+
+    private static final class RecordingBroker extends Broker
+    {
+        private final CopyOnWriteArrayList<String> events = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void publish(String topic, byte[] payload)
+        {
+            String value = payload == null ? "" : new String(payload, StandardCharsets.UTF_8);
+            events.add(topic + ":" + value);
+        }
+
+        List<String> events()
+        {
+            return events;
+        }
+    }
+}

--- a/src/test/java/com/can/core/CacheSegmentTest.java
+++ b/src/test/java/com/can/core/CacheSegmentTest.java
@@ -1,0 +1,205 @@
+package com.can.core;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CacheSegmentTest
+{
+    private CacheSegment<String> segment;
+    private TestEvictionPolicy policy;
+    private List<String> removals;
+
+    @BeforeEach
+    void setup()
+    {
+        policy = new TestEvictionPolicy();
+        removals = new ArrayList<>();
+        segment = new CacheSegment<>(2, policy, removals::add);
+    }
+
+    @Nested
+    class PutOperations
+    {
+        @Test
+        void put_stores_value_when_policy_admits()
+        {
+            CacheValue value = new CacheValue(new byte[]{1}, 0);
+            assertTrue(segment.put("a", value));
+            assertSame(value, segment.get("a"));
+            assertEquals(List.of("a"), policy.recordedKeys);
+        }
+
+        @Test
+        void put_rejects_when_policy_disallows()
+        {
+            policy.decision = EvictionPolicy.AdmissionDecision.reject();
+            assertFalse(segment.put("a", new CacheValue(new byte[]{1}, 0)));
+            assertNull(segment.get("a"));
+            assertTrue(policy.removedKeys.isEmpty());
+        }
+
+        @Test
+        void put_evicts_victim_and_notifies()
+        {
+            segment.put("victim", new CacheValue(new byte[]{1}, 0));
+            policy.decision = EvictionPolicy.AdmissionDecision.admit("victim");
+            CacheValue replacement = new CacheValue(new byte[]{2}, 0);
+
+            assertTrue(segment.put("new", replacement));
+            assertSame(replacement, segment.get("new"));
+            assertEquals(List.of("victim"), policy.removedKeys);
+            assertEquals(List.of("victim"), removals);
+        }
+
+        @Test
+        void put_force_removes_oldest_entry()
+        {
+            segment.put("a", new CacheValue(new byte[]{1}, 0));
+            segment.put("b", new CacheValue(new byte[]{2}, 0));
+
+            CacheValue forced = new CacheValue(new byte[]{3}, 0);
+            assertTrue(segment.putForce("c", forced));
+            assertNull(segment.get("a"));
+            assertSame(forced, segment.get("c"));
+            assertTrue(policy.removedKeys.contains("a"));
+            assertTrue(removals.contains("a"));
+        }
+    }
+
+    @Nested
+    class RetrievalOperations
+    {
+        @Test
+        void get_records_access_when_value_present()
+        {
+            CacheValue value = new CacheValue(new byte[]{1}, 0);
+            segment.put("a", value);
+            assertSame(value, segment.get("a"));
+            assertTrue(policy.recordedKeys.contains("a"));
+        }
+
+        @Test
+        void remove_if_matches_honours_expire_at()
+        {
+            CacheValue value = new CacheValue(new byte[]{1}, 123L);
+            segment.put("a", value);
+            assertTrue(segment.removeIfMatches("a", 123L));
+            assertFalse(segment.removeIfMatches("a", 123L));
+            assertEquals(List.of("a"), policy.removedKeys);
+            assertEquals(List.of("a"), removals);
+        }
+    }
+
+    @Nested
+    class CasOperations
+    {
+        @Test
+        void compare_and_swap_updates_when_successful()
+        {
+            CacheValue initial = new CacheValue(new byte[]{1}, 0);
+            segment.put("a", initial);
+
+            CacheSegment.CasResult result = segment.compareAndSwap("a", existing ->
+                    CacheSegment.CasDecision.success(new CacheValue(new byte[]{2}, 5L)));
+
+            assertTrue(result.success());
+            CacheValue stored = segment.get("a");
+            assertNotNull(stored);
+            assertArrayEquals(new byte[]{2}, stored.value);
+            assertEquals(5L, stored.expireAtMillis);
+            assertTrue(policy.recordedKeys.contains("a"));
+        }
+
+        @Test
+        void compare_and_swap_expired_entry_removes_and_notifies()
+        {
+            CacheValue initial = new CacheValue(new byte[]{1}, 0);
+            segment.put("a", initial);
+
+            CacheSegment.CasResult result = segment.compareAndSwap("a", existing -> CacheSegment.CasDecision.expired());
+
+            assertFalse(result.success());
+            assertNull(segment.get("a"));
+            assertEquals(List.of("a"), policy.removedKeys);
+            assertEquals(List.of("a"), removals);
+        }
+
+        @Test
+        void compare_and_swap_returns_failure_when_decision_null()
+        {
+            CacheValue initial = new CacheValue(new byte[]{1}, 0);
+            segment.put("a", initial);
+
+            CacheSegment.CasResult result = segment.compareAndSwap("a", existing -> null);
+
+            assertFalse(result.success());
+            assertNull(result.newValue());
+            assertSame(initial, segment.get("a"));
+        }
+    }
+
+    @Nested
+    class MaintenanceOperations
+    {
+        @Test
+        void clear_invokes_policy_removals()
+        {
+            segment.put("a", new CacheValue(new byte[]{1}, 0));
+            segment.put("b", new CacheValue(new byte[]{2}, 0));
+
+            segment.clear();
+
+            assertEquals(List.of("a", "b"), policy.removedKeys);
+            assertTrue(removals.isEmpty());
+            assertEquals(0, segment.size());
+        }
+
+        @Test
+        void for_each_iterates_snapshot()
+        {
+            segment.put("a", new CacheValue(new byte[]{1}, 0));
+            segment.put("b", new CacheValue(new byte[]{2}, 0));
+
+            List<String> seen = new ArrayList<>();
+            segment.forEach((key, value) -> {
+                seen.add(key + value.value[0]);
+                segment.put("c", new CacheValue(new byte[]{3}, 0));
+            });
+
+            assertEquals(List.of("a1", "b2"), seen);
+            assertNotNull(segment.get("c"));
+        }
+    }
+
+    private static final class TestEvictionPolicy implements EvictionPolicy<String>
+    {
+        EvictionPolicy.AdmissionDecision<String> decision = EvictionPolicy.AdmissionDecision.admit();
+        final List<String> recordedKeys = new ArrayList<>();
+        final List<String> removedKeys = new ArrayList<>();
+
+        @Override
+        public void recordAccess(String key)
+        {
+            recordedKeys.add(key);
+        }
+
+        @Override
+        public AdmissionDecision<String> admit(String key, LinkedHashMap<String, CacheValue> map, int capacity)
+        {
+            return decision;
+        }
+
+        @Override
+        public void onRemove(String key)
+        {
+            removedKeys.add(key);
+        }
+    }
+}

--- a/src/test/java/com/can/core/EvictionPoliciesTest.java
+++ b/src/test/java/com/can/core/EvictionPoliciesTest.java
@@ -1,0 +1,96 @@
+package com.can.core;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EvictionPoliciesTest
+{
+    @Nested
+    class LruPolicy
+    {
+        private final LruEvictionPolicy<String> policy = new LruEvictionPolicy<>();
+
+        @Test
+        void admit_allows_when_capacity_not_reached()
+        {
+            LinkedHashMap<String, CacheValue> map = new LinkedHashMap<>();
+            map.put("a", new CacheValue(new byte[]{1}, 0));
+            EvictionPolicy.AdmissionDecision<String> decision = policy.admit("b", map, 2);
+            assertTrue(decision.shouldAdmit());
+            assertNull(decision.evictKey());
+        }
+
+        @Test
+        void admit_evicts_eldest_when_full()
+        {
+            LinkedHashMap<String, CacheValue> map = new LinkedHashMap<>();
+            map.put("first", new CacheValue(new byte[]{1}, 0));
+            map.put("second", new CacheValue(new byte[]{2}, 0));
+
+            EvictionPolicy.AdmissionDecision<String> decision = policy.admit("third", map, 2);
+            assertTrue(decision.shouldAdmit());
+            assertEquals("first", decision.evictKey());
+        }
+    }
+
+    @Nested
+    class TinyLfuPolicy
+    {
+        @Test
+        void admit_rejects_when_candidate_less_frequent()
+        {
+            TinyLfuEvictionPolicy<String> policy = new TinyLfuEvictionPolicy<>(1);
+            LinkedHashMap<String, CacheValue> map = new LinkedHashMap<>();
+            map.put("victim", new CacheValue(new byte[]{1}, 0));
+
+            for (int i = 0; i < 10; i++) policy.recordAccess("victim");
+            policy.recordAccess("candidate");
+
+            EvictionPolicy.AdmissionDecision<String> decision = policy.admit("candidate", map, 1);
+            assertFalse(decision.shouldAdmit());
+        }
+
+        @Test
+        void admit_prefers_more_frequent_candidate()
+        {
+            TinyLfuEvictionPolicy<String> policy = new TinyLfuEvictionPolicy<>(1);
+            LinkedHashMap<String, CacheValue> map = new LinkedHashMap<>();
+            map.put("victim", new CacheValue(new byte[]{1}, 0));
+
+            for (int i = 0; i < 5; i++) policy.recordAccess("victim");
+            for (int i = 0; i < 20; i++) policy.recordAccess("candidate");
+
+            EvictionPolicy.AdmissionDecision<String> decision = policy.admit("candidate", map, 1);
+            assertTrue(decision.shouldAdmit());
+            assertEquals("victim", decision.evictKey());
+        }
+    }
+
+    @Nested
+    class TypeMapping
+    {
+        @Test
+        void from_config_defaults_to_lru()
+        {
+            assertEquals(EvictionPolicyType.LRU, EvictionPolicyType.fromConfig(null));
+            assertEquals(EvictionPolicyType.LRU, EvictionPolicyType.fromConfig(""));
+        }
+
+        @Test
+        void from_config_accepts_various_formats()
+        {
+            assertEquals(EvictionPolicyType.TINY_LFU, EvictionPolicyType.fromConfig("tiny-lfu"));
+            assertEquals(EvictionPolicyType.LRU, EvictionPolicyType.fromConfig("lru"));
+        }
+
+        @Test
+        void from_config_rejects_unknown_values()
+        {
+            assertThrows(IllegalArgumentException.class, () -> EvictionPolicyType.fromConfig("unknown"));
+        }
+    }
+}

--- a/src/test/java/com/can/core/ExpiringKeyTest.java
+++ b/src/test/java/com/can/core/ExpiringKeyTest.java
@@ -1,0 +1,35 @@
+package com.can.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExpiringKeyTest
+{
+    @Test
+    void get_delay_converts_milliseconds_to_requested_unit()
+    {
+        long target = System.currentTimeMillis() + 200;
+        ExpiringKey key = new ExpiringKey("k", 0, target);
+
+        long delayMillis = key.getDelay(TimeUnit.MILLISECONDS);
+        long delaySeconds = key.getDelay(TimeUnit.SECONDS);
+
+        assertTrue(delayMillis <= 200 && delayMillis >= 0);
+        assertTrue(delaySeconds <= 1);
+    }
+
+    @Test
+    void compare_to_orders_by_expiration()
+    {
+        long now = System.currentTimeMillis();
+        ExpiringKey sooner = new ExpiringKey("a", 0, now + 50);
+        ExpiringKey later = new ExpiringKey("b", 0, now + 100);
+
+        assertTrue(sooner.compareTo(later) < 0);
+        assertTrue(later.compareTo(sooner) > 0);
+        assertEquals(0, sooner.compareTo(new ExpiringKey("c", 0, sooner.expireAtMillis())));
+    }
+}

--- a/src/test/java/com/can/core/StoredValueCodecTest.java
+++ b/src/test/java/com/can/core/StoredValueCodecTest.java
@@ -1,0 +1,101 @@
+package com.can.core;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StoredValueCodecTest
+{
+    @Nested
+    class DecodeBehaviour
+    {
+        @Test
+        void decode_returns_legacy_when_not_base64()
+        {
+            StoredValueCodec.StoredValue value = StoredValueCodec.decode("not-base64");
+            assertFalse(value.hasMetadata());
+            assertArrayEquals("not-base64".getBytes(StandardCharsets.UTF_8), value.value());
+        }
+
+        @Test
+        void decode_returns_legacy_when_payload_too_short()
+        {
+            String encoded = java.util.Base64.getEncoder().encodeToString(new byte[]{1, 2, 3});
+            StoredValueCodec.StoredValue value = StoredValueCodec.decode(encoded);
+            assertFalse(value.hasMetadata());
+            assertArrayEquals(new byte[]{1, 2, 3}, value.value());
+        }
+
+        @Test
+        void decode_roundtrip_preserves_fields()
+        {
+            byte[] payload = "value".getBytes(StandardCharsets.UTF_8);
+            StoredValueCodec.StoredValue original = new StoredValueCodec.StoredValue(payload, 7, 42L, 1234L);
+            String encoded = StoredValueCodec.encode(original);
+            StoredValueCodec.StoredValue decoded = StoredValueCodec.decode(encoded);
+
+            assertTrue(decoded.hasMetadata());
+            assertArrayEquals(payload, decoded.value());
+            assertEquals(7, decoded.flags());
+            assertEquals(42L, decoded.cas());
+            assertEquals(1234L, decoded.expireAt());
+        }
+    }
+
+    @Nested
+    class MutationOperations
+    {
+        @Test
+        void with_value_updates_payload_and_cas()
+        {
+            StoredValueCodec.StoredValue base = new StoredValueCodec.StoredValue("v1".getBytes(StandardCharsets.UTF_8), 1, 10L, 100L);
+            StoredValueCodec.StoredValue updated = base.withValue("v2".getBytes(StandardCharsets.UTF_8), 11L);
+
+            assertArrayEquals("v2".getBytes(StandardCharsets.UTF_8), updated.value());
+            assertEquals(11L, updated.cas());
+            assertEquals(1, updated.flags());
+            assertEquals(100L, updated.expireAt());
+        }
+
+        @Test
+        void with_meta_replaces_all_fields()
+        {
+            StoredValueCodec.StoredValue base = new StoredValueCodec.StoredValue("v1".getBytes(StandardCharsets.UTF_8), 1, 10L, 100L);
+            StoredValueCodec.StoredValue updated = base.withMeta("v3".getBytes(StandardCharsets.UTF_8), 5, 99L, 200L);
+
+            assertArrayEquals("v3".getBytes(StandardCharsets.UTF_8), updated.value());
+            assertEquals(5, updated.flags());
+            assertEquals(99L, updated.cas());
+            assertEquals(200L, updated.expireAt());
+        }
+
+        @Test
+        void with_expire_at_updates_only_expiration()
+        {
+            StoredValueCodec.StoredValue base = new StoredValueCodec.StoredValue("v1".getBytes(StandardCharsets.UTF_8), 1, 10L, 100L);
+            StoredValueCodec.StoredValue updated = base.withExpireAt(500L, 12L);
+
+            assertArrayEquals(base.value(), updated.value());
+            assertEquals(1, updated.flags());
+            assertEquals(12L, updated.cas());
+            assertEquals(500L, updated.expireAt());
+        }
+
+        @Test
+        void expired_returns_true_when_now_beyond_expire()
+        {
+            StoredValueCodec.StoredValue base = new StoredValueCodec.StoredValue(new byte[]{1}, 0, 0L, System.currentTimeMillis() - 1);
+            assertTrue(base.expired(System.currentTimeMillis()));
+        }
+
+        @Test
+        void expired_ignores_max_value()
+        {
+            StoredValueCodec.StoredValue base = new StoredValueCodec.StoredValue(new byte[]{1}, 0, 0L, Long.MAX_VALUE);
+            assertFalse(base.expired(System.currentTimeMillis()));
+        }
+    }
+}

--- a/src/test/java/com/can/metric/MetricsComponentsTest.java
+++ b/src/test/java/com/can/metric/MetricsComponentsTest.java
@@ -1,0 +1,87 @@
+package com.can.metric;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MetricsComponentsTest
+{
+    @Nested
+    class CounterBehaviour
+    {
+        @Test
+        void counter_increments_and_adds()
+        {
+            Counter counter = new Counter("hits");
+            counter.inc();
+            counter.add(4);
+            assertEquals(5, counter.get());
+            assertEquals("hits", counter.name());
+        }
+    }
+
+    @Nested
+    class TimerBehaviour
+    {
+        @Test
+        void timer_records_statistics()
+        {
+            Timer timer = new Timer("latency", 128);
+            timer.record(1000);
+            timer.record(2000);
+            Timer.Sample sample = timer.snapshot();
+
+            assertEquals("latency", sample.name());
+            assertEquals(2, sample.count());
+            assertEquals(3000, sample.totalNs());
+            assertEquals(1000, sample.minNs());
+            assertEquals(2000, sample.maxNs());
+            assertTrue(sample.avgNs() >= 1500 && sample.avgNs() <= 2000);
+            assertTrue(sample.p95Ns() >= 0);
+        }
+    }
+
+    @Nested
+    class RegistryBehaviour
+    {
+        @Test
+        void registry_reuses_same_instances()
+        {
+            MetricsRegistry registry = new MetricsRegistry();
+            Counter c1 = registry.counter("requests");
+            Counter c2 = registry.counter("requests");
+            Timer t1 = registry.timer("latency");
+            Timer t2 = registry.timer("latency");
+
+            assertSame(c1, c2);
+            assertSame(t1, t2);
+            assertTrue(registry.counters().containsKey("requests"));
+            assertTrue(registry.timers().containsKey("latency"));
+        }
+    }
+
+    @Nested
+    class ReporterBehaviour
+    {
+        @Test
+        void reporter_starts_and_stops_safely() throws Exception
+        {
+            MetricsRegistry registry = new MetricsRegistry();
+            MetricsReporter reporter = new MetricsReporter(registry, 1);
+            reporter.start(1);
+            assertTrue(reporter.isRunning());
+            reporter.close();
+            assertFalse(reporter.isRunning());
+        }
+
+        @Test
+        void reporter_ignores_invalid_interval()
+        {
+            MetricsRegistry registry = new MetricsRegistry();
+            MetricsReporter reporter = new MetricsReporter(registry, 0);
+            reporter.start(0);
+            assertFalse(reporter.isRunning());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add targeted CacheSegment scenarios covering puts, removals, CAS and iteration flows
- exercise CacheEngine builder features including metrics, TTL expiry, replay and removal listeners
- cover supporting infrastructure such as eviction policies, codecs, metrics utilities and clustering client

## Testing
- `mvn test` *(fails: repository downloads blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19cbbeac88323836f3327b1b12ac0