### PR TITLE
Implement epoch handshake and replication repairs

### DIFF
--- a/src/main/java/com/can/cluster/ClusterClient.java
+++ b/src/main/java/com/can/cluster/ClusterClient.java
@@ -1,60 +1,173 @@
 package com.can.cluster;
 
 import com.can.codec.Codec;
+import org.jboss.logging.Logger;
+
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Tutarlı hash halkası üzerinden anahtarları ilgili düğümlere yönlendirerek
- * küme içinde okuma/yazma işlemlerini çoğaltan istemci katmanıdır. Anahtarları
- * verilen codec ile bayt dizisine çevirir, belirlenen replikasyon faktörü kadar
- * düğüm seçer ve her işlemde tüm kopyalara ulaşıp tutarlılığı sağlar.
+ * yazma/okuma işlemlerini gerçekleştiren istemci katmanıdır. Lider izleme
+ * yaklaşımıyla ilk düğüm lider kabul edilir, çoğunluk onayı alındığında işlem
+ * başarılı sayılır. Uzak düğümler geçici olarak ulaşılamadığında ipucu-handoff
+ * mekanizması devreye girer.
  */
-public record ClusterClient<K, V>(ConsistentHashRing<Node<K, V>> ring, int replicationFactor, Codec<K> keyCodec)
+public final class ClusterClient
 {
-    public ClusterClient(ConsistentHashRing<Node<K, V>> ring, int replicationFactor, Codec<K> keyCodec) {
-        this.ring = ring;
+    private static final Logger LOG = Logger.getLogger(ClusterClient.class);
+
+    private final ConsistentHashRing<Node<String, String>> ring;
+    private final int replicationFactor;
+    private final Codec<String> keyCodec;
+    private final HintedHandoffService hintedHandoffService;
+
+    public ClusterClient(ConsistentHashRing<Node<String, String>> ring,
+                         int replicationFactor,
+                         Codec<String> keyCodec,
+                         HintedHandoffService hintedHandoffService)
+    {
+        this.ring = Objects.requireNonNull(ring, "ring");
         this.replicationFactor = Math.max(1, replicationFactor);
-        this.keyCodec = keyCodec;
+        this.keyCodec = Objects.requireNonNull(keyCodec, "keyCodec");
+        this.hintedHandoffService = Objects.requireNonNull(hintedHandoffService, "hintedHandoffService");
     }
 
-    private List<Node<K, V>> replicas(K key) {
-        return ring.getReplicas(keyCodec.encode(key), replicationFactor);
+    private List<Node<String, String>> replicas(String key)
+    {
+        return new ArrayList<>(ring.getReplicas(keyCodec.encode(key), replicationFactor));
     }
 
-    public boolean set(K key, V value, Duration ttl) {
-        boolean success = true;
-        for (var n : replicas(key)) {
-            success &= n.set(key, value, ttl);
+    private int majority(int nodes)
+    {
+        return (nodes / 2) + 1;
+    }
+
+    public boolean set(String key, String value, Duration ttl)
+    {
+        List<Node<String, String>> nodes = replicas(key);
+        if (nodes.isEmpty()) {
+            return false;
         }
-        return success;
+        int quorum = majority(nodes.size());
+        int successes = 0;
+        RuntimeException leaderFailure = null;
+
+        for (int i = 0; i < nodes.size(); i++) {
+            Node<String, String> node = nodes.get(i);
+            boolean ok;
+            try {
+                ok = node.set(key, value, ttl);
+            } catch (RuntimeException e) {
+                LOG.debugf(e, "Failed to write key %s on node %s", key, node.id());
+                hintedHandoffService.recordSet(node.id(), key, value, ttl);
+                if (i == 0) {
+                    leaderFailure = e;
+                }
+                continue;
+            }
+
+            if (ok) {
+                successes++;
+            } else if (i > 0) {
+                hintedHandoffService.recordSet(node.id(), key, value, ttl);
+            }
+        }
+
+        if (successes >= quorum) {
+            return true;
+        }
+        if (leaderFailure != null) {
+            throw leaderFailure;
+        }
+        return false;
     }
 
-    public V get(K key) {
-        for (var n : replicas(key)) {
-            V v = n.get(key);
-            if (v != null) return v;
+    public String get(String key)
+    {
+        List<Node<String, String>> nodes = replicas(key);
+        for (Node<String, String> node : nodes) {
+            String value = node.get(key);
+            if (value != null) {
+                return value;
+            }
         }
         return null;
     }
 
-    public boolean delete(K key) {
-        boolean ok = false;
-        for (var n : replicas(key)) ok |= n.delete(key);
-        return ok;
-    }
-
-    public boolean compareAndSwap(K key, V value, long expectedCas, Duration ttl) {
-        boolean success = true;
-        for (var n : replicas(key)) {
-            success &= n.compareAndSwap(key, value, expectedCas, ttl);
+    public boolean delete(String key)
+    {
+        List<Node<String, String>> nodes = replicas(key);
+        if (nodes.isEmpty()) {
+            return false;
         }
-        return success;
+        int quorum = majority(nodes.size());
+        int successes = 0;
+        for (int i = 0; i < nodes.size(); i++) {
+            Node<String, String> node = nodes.get(i);
+            try {
+                if (node.delete(key)) {
+                    successes++;
+                } else if (i > 0) {
+                    hintedHandoffService.recordDelete(node.id(), key);
+                }
+            } catch (RuntimeException e) {
+                LOG.debugf(e, "Failed to delete key %s on node %s", key, node.id());
+                hintedHandoffService.recordDelete(node.id(), key);
+            }
+        }
+        return successes >= quorum;
     }
 
-    public void clear() {
-        for (var node : ring.nodes()) {
-            node.clear();
+    public boolean compareAndSwap(String key, String value, long expectedCas, Duration ttl)
+    {
+        List<Node<String, String>> nodes = replicas(key);
+        if (nodes.isEmpty()) {
+            return false;
+        }
+        int quorum = majority(nodes.size());
+        int successes = 0;
+        RuntimeException leaderFailure = null;
+
+        for (int i = 0; i < nodes.size(); i++) {
+            Node<String, String> node = nodes.get(i);
+            boolean ok;
+            try {
+                ok = node.compareAndSwap(key, value, expectedCas, ttl);
+            } catch (RuntimeException e) {
+                LOG.debugf(e, "Failed to CAS key %s on node %s", key, node.id());
+                hintedHandoffService.recordCas(node.id(), key, value, expectedCas, ttl);
+                if (i == 0) {
+                    leaderFailure = e;
+                }
+                continue;
+            }
+            if (ok) {
+                successes++;
+            } else if (i > 0) {
+                hintedHandoffService.recordCas(node.id(), key, value, expectedCas, ttl);
+            }
+        }
+
+        if (successes >= quorum) {
+            return true;
+        }
+        if (leaderFailure != null) {
+            throw leaderFailure;
+        }
+        return false;
+    }
+
+    public void clear()
+    {
+        for (Node<String, String> node : ring.nodes()) {
+            try {
+                node.clear();
+            } catch (RuntimeException e) {
+                LOG.debugf(e, "Failed to clear node %s", node.id());
+            }
         }
     }
 }

--- a/src/main/java/com/can/cluster/ClusterState.java
+++ b/src/main/java/com/can/cluster/ClusterState.java
@@ -1,0 +1,75 @@
+package com.can.cluster;
+
+import com.can.metric.Counter;
+import com.can.metric.MetricsRegistry;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Kümeye ait kimlik ve sürüm bilgisini takip eden hafif durum nesnesidir. Üyelik
+ * değiştikçe epoch değeri artırılır, uzak düğümlerden gelen epoch bilgileri
+ * görüldüğünde daha büyük değerler benimsenir. Metrik kayıt defteri ile
+ * entegredir ve kümeye dair gözlemlenebilirlik ihtiyacını destekler.
+ */
+public final class ClusterState
+{
+    private final String localNodeId;
+    private final byte[] localNodeIdBytes;
+    private final AtomicLong epoch = new AtomicLong(1L);
+    private final Counter epochIncrements;
+    private final Counter observedEpochUpdates;
+
+    public ClusterState(String localNodeId, MetricsRegistry metrics)
+    {
+        this.localNodeId = Objects.requireNonNull(localNodeId, "localNodeId");
+        this.localNodeIdBytes = localNodeId.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        if (metrics != null) {
+            this.epochIncrements = metrics.counter("cluster_epoch_increments");
+            this.observedEpochUpdates = metrics.counter("cluster_epoch_observed_updates");
+        } else {
+            this.epochIncrements = null;
+            this.observedEpochUpdates = null;
+        }
+    }
+
+    public String localNodeId()
+    {
+        return localNodeId;
+    }
+
+    public byte[] localNodeIdBytes()
+    {
+        return localNodeIdBytes.clone();
+    }
+
+    public long currentEpoch()
+    {
+        return epoch.get();
+    }
+
+    public long bumpEpoch()
+    {
+        long value = epoch.incrementAndGet();
+        if (epochIncrements != null) {
+            epochIncrements.inc();
+        }
+        return value;
+    }
+
+    public void observeEpoch(long remoteEpoch)
+    {
+        if (remoteEpoch <= 0) {
+            return;
+        }
+        epoch.updateAndGet(current -> {
+            if (remoteEpoch > current) {
+                if (observedEpochUpdates != null) {
+                    observedEpochUpdates.inc();
+                }
+                return remoteEpoch;
+            }
+            return current;
+        });
+    }
+}

--- a/src/main/java/com/can/cluster/ConsistentHashRing.java
+++ b/src/main/java/com/can/cluster/ConsistentHashRing.java
@@ -1,5 +1,6 @@
 package com.can.cluster;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -56,5 +57,11 @@ public final class ConsistentHashRing<N>
     public synchronized List<N> nodes() {
         return new ArrayList<>(new LinkedHashSet<>(ring.values()));
     }
-    private static byte[] join(byte[] id, int i){ return (new String(id)+"#"+i).getBytes(); }
+    private static byte[] join(byte[] id, int i){
+        byte[] suffix = ("#" + i).getBytes(StandardCharsets.UTF_8);
+        byte[] combined = new byte[id.length + suffix.length];
+        System.arraycopy(id, 0, combined, 0, id.length);
+        System.arraycopy(suffix, 0, combined, id.length, suffix.length);
+        return combined;
+    }
 }

--- a/src/main/java/com/can/cluster/HintedHandoffService.java
+++ b/src/main/java/com/can/cluster/HintedHandoffService.java
@@ -1,0 +1,158 @@
+package com.can.cluster;
+
+import com.can.metric.Counter;
+import com.can.metric.MetricsRegistry;
+import org.jboss.logging.Logger;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * Uzak düğümlere gönderilemeyen yazma işlemlerini kuyrukta tutarak düğüm geri
+ * geldiğinde yeniden oynatılmasını sağlayan basit ipucu-handoff hizmetidir.
+ */
+public final class HintedHandoffService
+{
+    private static final Logger LOG = Logger.getLogger(HintedHandoffService.class);
+
+    private final Map<String, ConcurrentLinkedDeque<Hint>> hints = new ConcurrentHashMap<>();
+    private final Counter enqueued;
+    private final Counter replayed;
+    private final Counter replayFailures;
+
+    public HintedHandoffService(MetricsRegistry metrics)
+    {
+        if (metrics != null) {
+            this.enqueued = metrics.counter("hinted_handoff_enqueued_total");
+            this.replayed = metrics.counter("hinted_handoff_replayed_total");
+            this.replayFailures = metrics.counter("hinted_handoff_failures_total");
+        } else {
+            this.enqueued = null;
+            this.replayed = null;
+            this.replayFailures = null;
+        }
+    }
+
+    public void recordSet(String nodeId, String key, String value, Duration ttl)
+    {
+        enqueue(nodeId, new SetHint(key, value, ttl));
+    }
+
+    public void recordDelete(String nodeId, String key)
+    {
+        enqueue(nodeId, new DeleteHint(key));
+    }
+
+    public void recordCas(String nodeId, String key, String value, long expectedCas, Duration ttl)
+    {
+        enqueue(nodeId, new CasHint(key, value, expectedCas, ttl));
+    }
+
+    private void enqueue(String nodeId, Hint hint)
+    {
+        Objects.requireNonNull(nodeId, "nodeId");
+        Objects.requireNonNull(hint, "hint");
+        hints.computeIfAbsent(nodeId, ignored -> new ConcurrentLinkedDeque<>()).add(hint);
+        if (enqueued != null) {
+            enqueued.inc();
+        }
+    }
+
+    public int pendingFor(String nodeId)
+    {
+        var queue = hints.get(nodeId);
+        return queue == null ? 0 : queue.size();
+    }
+
+    public void replay(String nodeId, com.can.cluster.Node<String, String> node)
+    {
+        Objects.requireNonNull(nodeId, "nodeId");
+        Objects.requireNonNull(node, "node");
+        var queue = hints.get(nodeId);
+        if (queue == null || queue.isEmpty()) {
+            return;
+        }
+
+        int replayedCount = 0;
+        while (true) {
+            Hint hint = queue.poll();
+            if (hint == null) {
+                break;
+            }
+            try {
+                if (hint.replay(node)) {
+                    replayedCount++;
+                } else {
+                    LOG.debugf("Hint replay returned false for %s on node %s", hint, nodeId);
+                }
+            } catch (RuntimeException e) {
+                queue.addFirst(hint);
+                if (replayFailures != null) {
+                    replayFailures.inc();
+                }
+                LOG.debugf(e, "Failed to replay hint %s for node %s", hint, nodeId);
+                break;
+            }
+        }
+
+        if (queue.isEmpty()) {
+            hints.remove(nodeId, queue);
+        }
+        if (replayed != null && replayedCount > 0) {
+            replayed.add(replayedCount);
+        }
+    }
+
+    interface Hint
+    {
+        boolean replay(com.can.cluster.Node<String, String> node);
+    }
+
+    private record SetHint(String key, String value, Duration ttl) implements Hint
+    {
+        @Override
+        public boolean replay(com.can.cluster.Node<String, String> node)
+        {
+            return node.set(key, value, ttl);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "SetHint{" + key + '}';
+        }
+    }
+
+    private record DeleteHint(String key) implements Hint
+    {
+        @Override
+        public boolean replay(com.can.cluster.Node<String, String> node)
+        {
+            return node.delete(key);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "DeleteHint{" + key + '}';
+        }
+    }
+
+    private record CasHint(String key, String value, long expectedCas, Duration ttl) implements Hint
+    {
+        @Override
+        public boolean replay(com.can.cluster.Node<String, String> node)
+        {
+            return node.compareAndSwap(key, value, expectedCas, ttl);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "CasHint{" + key + '}';
+        }
+    }
+}

--- a/src/main/java/com/can/config/AppConfig.java
+++ b/src/main/java/com/can/config/AppConfig.java
@@ -1,8 +1,10 @@
 package com.can.config;
 
 import com.can.cluster.ClusterClient;
+import com.can.cluster.ClusterState;
 import com.can.cluster.ConsistentHashRing;
 import com.can.cluster.HashFn;
+import com.can.cluster.HintedHandoffService;
 import com.can.cluster.Node;
 import com.can.cluster.coordination.CoordinationService;
 import com.can.codec.StringCodec;
@@ -143,10 +145,26 @@ public class AppConfig {
 
     @Produces
     @Singleton
-    public ClusterClient<String, String> clusterClient(
+    public ClusterState clusterState(Node<String, String> localNode, MetricsRegistry metrics)
+    {
+        return new ClusterState(localNode.id(), metrics);
+    }
+
+    @Produces
+    @Singleton
+    public HintedHandoffService hintedHandoffService(MetricsRegistry metrics)
+    {
+        return new HintedHandoffService(metrics);
+    }
+
+    @Produces
+    @Singleton
+    public ClusterClient clusterClient(
             ConsistentHashRing<Node<String, String>> ring,
-            CoordinationService coordinationService
+            CoordinationService coordinationService,
+            HintedHandoffService hintedHandoffService
     ) {
-        return new ClusterClient<>(ring, properties.cluster().replicationFactor(), StringCodec.UTF8);
+        return new ClusterClient(ring, properties.cluster().replicationFactor(), StringCodec.UTF8,
+                hintedHandoffService);
     }
 }

--- a/src/main/java/com/can/core/CacheEngine.java
+++ b/src/main/java/com/can/core/CacheEngine.java
@@ -7,6 +7,7 @@ import com.can.metric.Timer;
 import com.can.pubsub.Broker;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.DelayQueue;
@@ -250,6 +251,17 @@ public final class CacheEngine<K,V> implements AutoCloseable
                 }
             });
         }
+    }
+
+    public long fingerprint()
+    {
+        final long[] hash = {1125899906842597L};
+        forEachEntry((key, value, expireAt) -> {
+            long entryHash = 31L * key.hashCode() + Arrays.hashCode(value);
+            entryHash = 31L * entryHash + Long.hashCode(expireAt);
+            hash[0] = 31L * hash[0] + entryHash;
+        });
+        return hash[0];
     }
 
     // Replay entry from persistence layer

--- a/src/main/java/com/can/net/CanCachedServer.java
+++ b/src/main/java/com/can/net/CanCachedServer.java
@@ -49,7 +49,7 @@ public class CanCachedServer implements AutoCloseable
     private static final int MAX_ITEM_SIZE = 1_048_576; // 1 MB
     private static final int MAX_CAS_RETRIES = 16;
 
-    private final ClusterClient<String, String> clusterClient;
+    private final ClusterClient clusterClient;
     private final AppProperties.Network networkConfig;
     private final CacheEngine<String, String> localEngine;
 
@@ -74,7 +74,7 @@ public class CanCachedServer implements AutoCloseable
     private AutoCloseable removalSubscription;
 
     @Inject
-    public CanCachedServer(ClusterClient<String, String> clusterClient, AppProperties properties, CacheEngine<String, String> localEngine) {
+    public CanCachedServer(ClusterClient clusterClient, AppProperties properties, CacheEngine<String, String> localEngine) {
         this.clusterClient = Objects.requireNonNull(clusterClient, "clusterClient");
         this.networkConfig = Objects.requireNonNull(properties.network(), "networkConfig");
         this.localEngine = Objects.requireNonNull(localEngine, "localEngine");

--- a/src/test/java/com/can/CanCacheApplicationTests.java
+++ b/src/test/java/com/can/CanCacheApplicationTests.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class CanCacheApplicationTests {
 
     @Inject
-    ClusterClient<String, String> cluster;
+    ClusterClient cluster;
 
     @Nested
     class ContainerWiring {

--- a/src/test/java/com/can/cluster/ClusterClientTest.java
+++ b/src/test/java/com/can/cluster/ClusterClientTest.java
@@ -1,6 +1,7 @@
 package com.can.cluster;
 
 import com.can.codec.StringCodec;
+import com.can.metric.MetricsRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,8 @@ class ClusterClientTest
     private ConsistentHashRing<Node<String, String>> ring;
     private TestNode node1;
     private TestNode node2;
-    private ClusterClient<String, String> client;
+    private ClusterClient client;
+    private HintedHandoffService hintedHandoff;
 
     @BeforeEach
     void setup()
@@ -27,7 +29,8 @@ class ClusterClientTest
         node2 = new TestNode("node2");
         ring.addNode(node1, node1.id().getBytes());
         ring.addNode(node2, node2.id().getBytes());
-        client = new ClusterClient<>(ring, 2, StringCodec.UTF8);
+        hintedHandoff = new HintedHandoffService(new MetricsRegistry());
+        client = new ClusterClient(ring, 2, StringCodec.UTF8, hintedHandoff);
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- introduce ClusterState-backed epoch tracking, include epoch in discovery heartbeats, and require TCP join handshakes before adding members
- add a hinted-handoff service plus leader-first, majority-based write logic to the cluster client
- extend the replication server with join/digest/stream commands and schedule anti-entropy repairs and bootstrap streaming in the coordination service

## Testing
- `./mvnw -q test` *(fails: wget could not fetch apache-maven-3.9.11-bin.zip from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d1af52dabc8323bf946e3611fc9e81