### PR TITLE
Handle local fallback for integration tests

### DIFF
--- a/integration-tests/src/test/java/com/can/cache/integration/CanCacheServiceLauncher.java
+++ b/integration-tests/src/test/java/com/can/cache/integration/CanCacheServiceLauncher.java
@@ -3,6 +3,7 @@ package com.can.cache.integration;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.LinkedHashSet;
 
 final class CanCacheServiceLauncher implements AutoCloseable {
 
@@ -13,13 +14,13 @@ final class CanCacheServiceLauncher implements AutoCloseable {
     }
 
     static CanCacheServiceLauncher ensureStarted() throws IOException {
-        String host = MemcacheTextClient.DEFAULT_HOST;
-        int port = MemcacheTextClient.DEFAULT_PORT;
-        if (isServiceReachable(host, port)) {
+        String configuredHost = MemcacheTextClient.configuredHost();
+        int configuredPort = MemcacheTextClient.configuredPort();
+        if (isServiceReachable(configuredHost, configuredPort)) {
+            MemcacheTextClient.overrideDefaultEndpoint(configuredHost, configuredPort);
             return new CanCacheServiceLauncher(null);
         }
-        EmbeddedCanCacheServer server = new EmbeddedCanCacheServer(host, port);
-        server.start();
+        EmbeddedCanCacheServer server = startEmbeddedServer(configuredHost, configuredPort);
         return new CanCacheServiceLauncher(server);
     }
 
@@ -30,6 +31,32 @@ final class CanCacheServiceLauncher implements AutoCloseable {
         } catch (IOException ignored) {
             return false;
         }
+    }
+
+    private static EmbeddedCanCacheServer startEmbeddedServer(String configuredHost, int port) throws IOException {
+        IOException lastError = null;
+        for (String candidate : candidateHosts(configuredHost)) {
+            EmbeddedCanCacheServer server = new EmbeddedCanCacheServer(candidate, port);
+            try {
+                server.start();
+                MemcacheTextClient.overrideDefaultEndpoint(candidate, port);
+                return server;
+            } catch (IOException ex) {
+                server.close();
+                lastError = ex;
+            }
+        }
+        if (lastError != null) {
+            throw lastError;
+        }
+        throw new IOException("Unable to start embedded server for host " + configuredHost + ':' + port);
+    }
+
+    private static Iterable<String> candidateHosts(String configuredHost) {
+        LinkedHashSet<String> hosts = new LinkedHashSet<>();
+        hosts.add(configuredHost);
+        hosts.add(MemcacheTextClient.loopbackHost());
+        return hosts;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- allow `MemcacheTextClient` to track an effective default endpoint, sanitize the configured values, and expose an override so tests can fall back to loopback when necessary
- update `CanCacheServiceLauncher` to retry startup on the loopback address when the configured host cannot be bound and keep the client defaults in sync

## Testing
- mvn -pl integration-tests test *(fails: Maven cannot download dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cd13ecfc8323bb23873fc133e8e2