### PR TITLE
Fix integration test multi-catch build failure

### DIFF
--- a/integration-tests/src/test/java/com/can/cache/integration/MemcacheTextClient.java
+++ b/integration-tests/src/test/java/com/can/cache/integration/MemcacheTextClient.java
@@ -335,7 +335,7 @@ public class MemcacheTextClient implements AutoCloseable {
         }
         try {
             return validatePort(Integer.parseInt(value.trim(), 10));
-        } catch (NumberFormatException | IllegalArgumentException ex) {
+        } catch (IllegalArgumentException ex) {
             return 11211;
         }
     }


### PR DESCRIPTION
## Summary
- catch only IllegalArgumentException when parsing the default port in `MemcacheTextClient` to avoid invalid multi-catch combinations on older compilers

## Testing
- ./mvnw -pl integration-tests test *(fails: unable to download Maven binary due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cfe84ca4832398dd71a3fec8fe0b