### PR TITLE
Fix empty value handling, TTL overflow, and CAS hints

### DIFF
--- a/src/main/java/com/can/cluster/ClusterClient.java
+++ b/src/main/java/com/can/cluster/ClusterClient.java
@@ -146,8 +146,6 @@ public final class ClusterClient
             }
             if (ok) {
                 successes++;
-            } else if (i > 0) {
-                hintedHandoffService.recordCas(node.id(), key, value, expectedCas, ttl);
             }
         }
 

--- a/src/main/java/com/can/codec/StringCodec.java
+++ b/src/main/java/com/can/codec/StringCodec.java
@@ -4,8 +4,8 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * Java {@link String} nesnelerini UTF-8 karakter setiyle kodlayıp çözen basit
- * codec implementasyonudur. Null değerleri boş diziye/boş referansa çevirerek
- * ağ ve disk operasyonlarında tutarlı davranış sergiler.
+ * codec implementasyonudur. Null değerleri boş diziye, boş dizileri ise boş
+ * string'e çevirerek ağ ve disk operasyonlarında tutarlı davranış sergiler.
  */
 public final class StringCodec implements Codec<String>
 {
@@ -19,6 +19,9 @@ public final class StringCodec implements Codec<String>
 
     @Override
     public String decode(byte[] bytes) {
-        return (bytes == null || bytes.length == 0) ? null : new String(bytes, StandardCharsets.UTF_8);
+        if (bytes == null) {
+            return null;
+        }
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/can/core/CacheEngine.java
+++ b/src/main/java/com/can/core/CacheEngine.java
@@ -133,8 +133,8 @@ public final class CacheEngine<K,V> implements AutoCloseable
     {
         long t0 = System.nanoTime();
         Objects.requireNonNull(key);
-        long expireAt = (ttl == null || ttl.isZero() || ttl.isNegative()) ? 0L
-                : System.currentTimeMillis() + ttl.toMillis();
+        long now = System.currentTimeMillis();
+        long expireAt = computeExpireAt(ttl, now);
         int idx = segIndex(key);
         boolean stored = seg(key).put(key, new CacheValue(valCodec.encode(value), expireAt));
         if (!stored) {

--- a/src/test/java/com/can/cluster/ClusterClientTest.java
+++ b/src/test/java/com/can/cluster/ClusterClientTest.java
@@ -86,6 +86,19 @@ class ClusterClientTest
             assertFalse(client.compareAndSwap("key", "new", expected, null));
             assertEquals("value", node1.get("key"));
         }
+
+        @Test
+        void compare_and_swap_does_not_enqueue_hint_on_logical_failure()
+        {
+            client.set("key", "value", null);
+            node2.forceCas("key", 999L);
+            long expected = node1.cas("key");
+
+            assertFalse(client.compareAndSwap("key", "new", expected, null));
+
+            assertEquals(0, hintedHandoff.pendingFor(node1.id()));
+            assertEquals(0, hintedHandoff.pendingFor(node2.id()));
+        }
     }
 
     @Nested

--- a/src/test/java/com/can/codec/CodecsTest.java
+++ b/src/test/java/com/can/codec/CodecsTest.java
@@ -22,11 +22,18 @@ class CodecsTest
         }
 
         @Test
-        void encode_and_decode_handles_null()
+        void encode_and_decode_handles_empty_string()
         {
             StringCodec codec = StringCodec.UTF8;
             assertArrayEquals(new byte[0], codec.encode(null));
-            assertNull(codec.decode(new byte[0]));
+            assertEquals("", codec.decode(new byte[0]));
+        }
+
+        @Test
+        void decode_returns_null_when_input_is_null()
+        {
+            StringCodec codec = StringCodec.UTF8;
+            assertNull(codec.decode(null));
         }
     }
 

--- a/src/test/java/com/can/core/CacheEngineTest.java
+++ b/src/test/java/com/can/core/CacheEngineTest.java
@@ -82,6 +82,24 @@ class CacheEngineTest
             assertFalse(engine.exists("key"));
             assertTrue(metrics.counter("cache_misses").get() > 0);
         }
+
+        @Test
+        void set_allows_empty_string_values()
+        {
+            assertTrue(engine.set("key", ""));
+            assertEquals("", engine.get("key"));
+        }
+
+        @Test
+        void set_handles_large_ttl_without_overflow()
+        {
+            long now = System.currentTimeMillis();
+            Duration ttl = Duration.ofMillis(Long.MAX_VALUE - now + 1000);
+
+            assertTrue(engine.set("key", "value", ttl));
+            assertEquals("value", engine.get("key"));
+            assertTrue(engine.exists("key"));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- return empty strings from `StringCodec.decode` for zero-length payloads while still permitting null inputs
- reuse `computeExpireAt` during `CacheEngine.set` to prevent TTL overflow and add regression tests
- avoid enqueuing hinted handoff entries on logical CAS failures and cover behavior with tests

## Testing
- `mvn test` *(fails: missing dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d26fafcc0c83239872439d88ea99bb