### PR TITLE
refactor: migrate TCP server to Vert.x event loop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Summary
- replace the blocking ServerSocket implementation with a Vert.x NetServer configured through the existing network properties
- stream and buffer client input per connection to parse memcached commands and deferred value payloads on the event loop
- execute cache operations on Vert.x worker threads while emitting protocol responses through Vert.x buffers to preserve existing semantics
- declare the quarkus-vertx extension and supply a fallback Vertx producer so a bean is available even without the extension
- expand the architecture guide in help.md to explain the Vert.x-based event loop model and connection lifecycle

## Testing
- ./mvnw test *(fails: unable to download Maven wrapper distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d299c3aac8832396c094fa5453655a