### PR TITLE
Revise integration tests for delayed flush semantics

### DIFF
--- a/integration-tests/src/test/java/com/can/cache/integration/MemcacheTextClient.java
+++ b/integration-tests/src/test/java/com/can/cache/integration/MemcacheTextClient.java
@@ -227,7 +227,25 @@ public class MemcacheTextClient implements AutoCloseable {
     }
 
     public String flushAll() throws IOException {
-        sendLine("flush_all");
+        return flushAll(0L, false);
+    }
+
+    public String flushAll(long delaySeconds) throws IOException {
+        return flushAll(delaySeconds, false);
+    }
+
+    public String flushAll(long delaySeconds, boolean noreply) throws IOException {
+        StringBuilder builder = new StringBuilder("flush_all");
+        if (delaySeconds > 0L) {
+            builder.append(' ').append(delaySeconds);
+        }
+        if (noreply) {
+            builder.append(" noreply");
+        }
+        sendLine(builder.toString());
+        if (noreply) {
+            return "";
+        }
         return readLine();
     }
 


### PR DESCRIPTION
## Summary
- extend the text client helper with `flush_all` overloads that support delays and `noreply`
- align the embedded compatibility server with the updated protocol semantics for delayed flushes, stats counters, and noreply handling
- expand the integration suite with checks for delayed flush behaviour and detailed stats counters

## Testing
- mvn -f integration-tests/pom.xml test *(fails: network is unreachable while downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d0781900832395a06e1eb3d6df8e