### PR TITLE
Configure Vert.x thread pools and native transport

### DIFF
--- a/src/main/java/com/can/config/AppConfig.java
+++ b/src/main/java/com/can/config/AppConfig.java
@@ -15,11 +15,13 @@ import com.can.rdb.SnapshotFile;
 import com.can.pubsub.Broker;
 import io.quarkus.arc.DefaultBean;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import java.io.File;
@@ -50,13 +52,51 @@ public class AppConfig {
     public Vertx vertx()
     {
         ownsVertx.set(true);
-        return Vertx.vertx();
+        var network = properties.network();
+
+        VertxOptions options = new VertxOptions();
+
+        int eventLoopThreads = network.eventLoopThreads();
+        if (eventLoopThreads <= 0) {
+            eventLoopThreads = VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE;
+        }
+        options.setEventLoopPoolSize(eventLoopThreads);
+
+        int workerThreads = Math.max(1, network.workerThreads());
+        options.setWorkerPoolSize(workerThreads);
+
+        if (shouldPreferNativeTransport()) {
+            options.setPreferNativeTransport(true);
+        }
+
+        return Vertx.vertx(options);
     }
 
     void disposeVertx(@Disposes Vertx vertx)
     {
         if (ownsVertx.get()) {
             vertx.close().toCompletionStage().toCompletableFuture().join();
+        }
+    }
+
+    private boolean shouldPreferNativeTransport()
+    {
+        String osName = System.getProperty("os.name", "");
+        if (osName == null || !osName.toLowerCase(Locale.ROOT).contains("linux")) {
+            return false;
+        }
+
+        return isNativeTransportAvailable("io.netty.channel.epoll.Epoll")
+                || isNativeTransportAvailable("io.netty.incubator.channel.uring.IOUring");
+    }
+
+    private boolean isNativeTransportAvailable(String className)
+    {
+        try {
+            Class<?> clazz = Class.forName(className);
+            return (boolean) clazz.getMethod("isAvailable").invoke(null);
+        } catch (ReflectiveOperationException | LinkageError e) {
+            return false;
         }
     }
 

--- a/src/main/java/com/can/config/AppProperties.java
+++ b/src/main/java/com/can/config/AppProperties.java
@@ -104,6 +104,9 @@ public interface AppProperties
         @WithDefault("128")
         int backlog();
 
+        @WithDefault("0")
+        int eventLoopThreads();
+
         @WithDefault("16")
         int workerThreads();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,7 @@ app.memcache.max-cas-retries=16
 app.network.host=0.0.0.0
 app.network.port=11211
 app.network.backlog=128
+app.network.event-loop-threads=8
 app.network.worker-threads=16
 
 # genel seviye
@@ -35,3 +36,4 @@ quarkus.log.file.enable=true
 quarkus.log.file.path=logs/app.log
 quarkus.log.file.rotation.max-file-size=10M
 quarkus.log.file.rotation.max-backup-index=7
+quarkus.vertx.prefer-native-transport=true


### PR DESCRIPTION
## Summary
- configure the Vert.x bean with network pool sizes from configuration and prefer native transport when available
- extend `AppProperties.Network` to expose an event loop thread setting
- document the new knobs in `application.properties` and enable Quarkus native transport support

## Testing
- ./mvnw -q test *(fails: unable to download Maven binaries in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ee8e730483239504ce6cd3e6a62e