### PR TITLE
Fix RemoteNode pooled connection state checks

### DIFF
--- a/src/main/java/com/can/cluster/coordination/RemoteNode.java
+++ b/src/main/java/com/can/cluster/coordination/RemoteNode.java
@@ -203,7 +203,7 @@ public final class RemoteNode implements Node<String, String>, AutoCloseable
             }
             PooledConnection pooled = pool.poll();
             if (pooled != null) {
-                if (!pooled.closed && !pooled.socket.isClosed()) {
+                if (!pooled.closed) {
                     pooled.socket.resume();
                     return pooled;
                 }
@@ -237,7 +237,7 @@ public final class RemoteNode implements Node<String, String>, AutoCloseable
             if (pooled == null) {
                 throw new IOException("Timeout acquiring pooled connection");
             }
-            if (!pooled.closed && !pooled.socket.isClosed()) {
+            if (!pooled.closed) {
                 pooled.socket.resume();
                 return pooled;
             }
@@ -296,7 +296,7 @@ public final class RemoteNode implements Node<String, String>, AutoCloseable
             return;
         }
         connection.clearInFlight();
-        if (closed.get() || connection.closed || connection.socket.isClosed()) {
+        if (closed.get() || connection.closed) {
             discard(connection);
             return;
         }


### PR DESCRIPTION
## Summary
- avoid calling the non-existent NetSocket#isClosed method when reusing pooled connections by relying on the connection's closed flag instead
- prevent releasing closed pooled connections back into the pool using the same closed flag

## Testing
- ./mvnw -q -DskipITs=true test *(fails: unable to download Maven due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fc2b041083238acaa889f7d48f1c