### PR TITLE
Refactor models into dedicated packages

### DIFF
--- a/src/main/java/com/can/cluster/HintedHandoffService.java
+++ b/src/main/java/com/can/cluster/HintedHandoffService.java
@@ -1,5 +1,9 @@
 package com.can.cluster;
 
+import com.can.cluster.handoff.CasHint;
+import com.can.cluster.handoff.DeleteHint;
+import com.can.cluster.handoff.Hint;
+import com.can.cluster.handoff.SetHint;
 import com.can.metric.Counter;
 import com.can.metric.MetricsRegistry;
 import org.jboss.logging.Logger;
@@ -103,56 +107,6 @@ public final class HintedHandoffService
         }
         if (replayed != null && replayedCount > 0) {
             replayed.add(replayedCount);
-        }
-    }
-
-    interface Hint
-    {
-        boolean replay(com.can.cluster.Node<String, String> node);
-    }
-
-    private record SetHint(String key, String value, Duration ttl) implements Hint
-    {
-        @Override
-        public boolean replay(com.can.cluster.Node<String, String> node)
-        {
-            return node.set(key, value, ttl);
-        }
-
-        @Override
-        public String toString()
-        {
-            return "SetHint{" + key + '}';
-        }
-    }
-
-    private record DeleteHint(String key) implements Hint
-    {
-        @Override
-        public boolean replay(com.can.cluster.Node<String, String> node)
-        {
-            return node.delete(key);
-        }
-
-        @Override
-        public String toString()
-        {
-            return "DeleteHint{" + key + '}';
-        }
-    }
-
-    private record CasHint(String key, String value, long expectedCas, Duration ttl) implements Hint
-    {
-        @Override
-        public boolean replay(com.can.cluster.Node<String, String> node)
-        {
-            return node.compareAndSwap(key, value, expectedCas, ttl);
-        }
-
-        @Override
-        public String toString()
-        {
-            return "CasHint{" + key + '}';
         }
     }
 }

--- a/src/main/java/com/can/cluster/handoff/CasHint.java
+++ b/src/main/java/com/can/cluster/handoff/CasHint.java
@@ -1,0 +1,29 @@
+package com.can.cluster.handoff;
+
+import com.can.cluster.Node;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * CAS işlemlerinin yeniden oynatılmasını sağlayan ipucu temsilidir.
+ */
+public record CasHint(String key, String value, long expectedCas, Duration ttl) implements Hint
+{
+    public CasHint
+    {
+        Objects.requireNonNull(key, "key");
+    }
+
+    @Override
+    public boolean replay(Node<String, String> node)
+    {
+        return node.compareAndSwap(key, value, expectedCas, ttl);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "CasHint{" + key + '}';
+    }
+}

--- a/src/main/java/com/can/cluster/handoff/DeleteHint.java
+++ b/src/main/java/com/can/cluster/handoff/DeleteHint.java
@@ -1,0 +1,28 @@
+package com.can.cluster.handoff;
+
+import com.can.cluster.Node;
+
+import java.util.Objects;
+
+/**
+ * İpucu kuyruğundaki bir silme operasyonunu temsil eder.
+ */
+public record DeleteHint(String key) implements Hint
+{
+    public DeleteHint
+    {
+        Objects.requireNonNull(key, "key");
+    }
+
+    @Override
+    public boolean replay(Node<String, String> node)
+    {
+        return node.delete(key);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "DeleteHint{" + key + '}';
+    }
+}

--- a/src/main/java/com/can/cluster/handoff/Hint.java
+++ b/src/main/java/com/can/cluster/handoff/Hint.java
@@ -1,0 +1,11 @@
+package com.can.cluster.handoff;
+
+import com.can.cluster.Node;
+
+/**
+ * Hinted handoff sırasında yeniden oynatılacak işlemleri temsil eder.
+ */
+public interface Hint
+{
+    boolean replay(Node<String, String> node);
+}

--- a/src/main/java/com/can/cluster/handoff/SetHint.java
+++ b/src/main/java/com/can/cluster/handoff/SetHint.java
@@ -1,0 +1,29 @@
+package com.can.cluster.handoff;
+
+import com.can.cluster.Node;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Uzak düğüme tekrar gönderilmesi gereken set operasyonunu temsil eder.
+ */
+public record SetHint(String key, String value, Duration ttl) implements Hint
+{
+    public SetHint
+    {
+        Objects.requireNonNull(key, "key");
+    }
+
+    @Override
+    public boolean replay(Node<String, String> node)
+    {
+        return node.set(key, value, ttl);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SetHint{" + key + '}';
+    }
+}

--- a/src/main/java/com/can/core/EvictionPolicy.java
+++ b/src/main/java/com/can/core/EvictionPolicy.java
@@ -1,5 +1,7 @@
 package com.can.core;
 
+import com.can.core.model.CacheValue;
+
 import java.util.LinkedHashMap;
 
 /**

--- a/src/main/java/com/can/core/LruEvictionPolicy.java
+++ b/src/main/java/com/can/core/LruEvictionPolicy.java
@@ -1,5 +1,7 @@
 package com.can.core;
 
+import com.can.core.model.CacheValue;
+
 import java.util.LinkedHashMap;
 
 /**

--- a/src/main/java/com/can/core/TinyLfuEvictionPolicy.java
+++ b/src/main/java/com/can/core/TinyLfuEvictionPolicy.java
@@ -1,5 +1,7 @@
 package com.can.core;
 
+import com.can.core.model.CacheValue;
+
 import java.util.LinkedHashMap;
 
 /**

--- a/src/main/java/com/can/core/model/CacheValue.java
+++ b/src/main/java/com/can/core/model/CacheValue.java
@@ -1,4 +1,4 @@
-package com.can.core;
+package com.can.core.model;
 
 /**
  * Önbellekte tutulan bayt değerini ve varsa son kullanma zamanını kapsülleyen
@@ -6,8 +6,8 @@ package com.can.core;
  *
  * @param expireAtMillis <=0: no TTL
  */
-record CacheValue(byte[] value, long expireAtMillis) {
-    boolean expired(long now) {
+public record CacheValue(byte[] value, long expireAtMillis) {
+    public boolean expired(long now) {
         return expireAtMillis > 0 && now >= expireAtMillis;
     }
 }

--- a/src/main/java/com/can/core/model/CasDecision.java
+++ b/src/main/java/com/can/core/model/CasDecision.java
@@ -1,0 +1,23 @@
+package com.can.core.model;
+
+/**
+ * Segment içindeki CAS kararının nasıl uygulanacağını tanımlar.
+ */
+public record CasDecision(boolean success,
+                          CacheValue newValue,
+                          boolean removeExisting,
+                          boolean notifyRemoval,
+                          boolean recordAccess)
+{
+    public static CasDecision success(CacheValue newValue) {
+        return new CasDecision(true, newValue, false, false, true);
+    }
+
+    public static CasDecision fail() {
+        return new CasDecision(false, null, false, false, false);
+    }
+
+    public static CasDecision expired() {
+        return new CasDecision(false, null, true, true, false);
+    }
+}

--- a/src/main/java/com/can/core/model/CasResult.java
+++ b/src/main/java/com/can/core/model/CasResult.java
@@ -1,0 +1,7 @@
+package com.can.core.model;
+
+/**
+ * CAS operasyonunun sonucunu ve oluşturulan değeri temsil eder.
+ */
+public record CasResult(boolean success, CacheValue newValue) {
+}

--- a/src/main/java/com/can/core/model/ExpiringKey.java
+++ b/src/main/java/com/can/core/model/ExpiringKey.java
@@ -1,4 +1,4 @@
-package com.can.core;
+package com.can.core.model;
 
 import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
  * Zamanı geldiğinde ilgili segmentten düşürülecek anahtarları temsil eden ve
  * {@link java.util.concurrent.DelayQueue} içinde kullanılan kayıt türüdür.
  */
-record ExpiringKey(Object key, int segmentIndex, long expireAtMillis) implements Delayed
+public record ExpiringKey(Object key, int segmentIndex, long expireAtMillis) implements Delayed
 {
     @Override
     public long getDelay(TimeUnit unit) {

--- a/src/main/java/com/can/net/CanCachedServer.java
+++ b/src/main/java/com/can/net/CanCachedServer.java
@@ -4,6 +4,11 @@ import com.can.cluster.ClusterClient;
 import com.can.config.AppProperties;
 import com.can.core.CacheEngine;
 import com.can.core.StoredValueCodec;
+import com.can.net.protocol.CommandAction;
+import com.can.net.protocol.CommandResult;
+import com.can.net.protocol.ImmediateCommand;
+import com.can.net.protocol.PendingStorageCommand;
+import com.can.net.protocol.StorageCommand;
 import io.quarkus.runtime.Startup;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -766,73 +771,6 @@ public class CanCachedServer implements AutoCloseable
             } catch (RuntimeException e) {
                 LOG.debug("Failed to close net server", e);
             }
-        }
-    }
-
-    private interface CommandAction
-    {
-    }
-
-    private static final class ImmediateCommand implements CommandAction
-    {
-        private final Supplier<CommandResult> executor;
-
-        private ImmediateCommand(Supplier<CommandResult> executor)
-        {
-            this.executor = executor;
-        }
-
-        private Supplier<CommandResult> executor()
-        {
-            return executor;
-        }
-    }
-
-    private static final class StorageCommand implements CommandAction
-    {
-        private final PendingStorageCommand pending;
-
-        private StorageCommand(PendingStorageCommand pending)
-        {
-            this.pending = pending;
-        }
-
-        private PendingStorageCommand pending()
-        {
-            return pending;
-        }
-    }
-
-    private record PendingStorageCommand(String command,
-                                         String key,
-                                         int flags,
-                                         Duration ttl,
-                                         int bytes,
-                                         boolean noreply,
-                                         boolean isCas,
-                                         long casUnique)
-    {
-        int totalLength()
-        {
-            return bytes + CRLF.length;
-        }
-    }
-
-    private record CommandResult(Buffer response, boolean keepAlive)
-    {
-        static CommandResult continueWith(Buffer response)
-        {
-            return new CommandResult(response, true);
-        }
-
-        static CommandResult continueWithoutResponse()
-        {
-            return new CommandResult(null, true);
-        }
-
-        static CommandResult terminate()
-        {
-            return new CommandResult(null, false);
         }
     }
 

--- a/src/main/java/com/can/net/protocol/CommandAction.java
+++ b/src/main/java/com/can/net/protocol/CommandAction.java
@@ -1,0 +1,8 @@
+package com.can.net.protocol;
+
+/**
+ * Bir istemci komutunun nasıl işleneceğini temsil eden işaretçi arayüz.
+ */
+public interface CommandAction
+{
+}

--- a/src/main/java/com/can/net/protocol/CommandResult.java
+++ b/src/main/java/com/can/net/protocol/CommandResult.java
@@ -1,0 +1,24 @@
+package com.can.net.protocol;
+
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * Bir komutun sonucunda istemciye gönderilecek cevabı ve bağlantı durumunu belirtir.
+ */
+public record CommandResult(Buffer response, boolean keepAlive)
+{
+    public static CommandResult continueWith(Buffer response)
+    {
+        return new CommandResult(response, true);
+    }
+
+    public static CommandResult continueWithoutResponse()
+    {
+        return new CommandResult(null, true);
+    }
+
+    public static CommandResult terminate()
+    {
+        return new CommandResult(null, false);
+    }
+}

--- a/src/main/java/com/can/net/protocol/ImmediateCommand.java
+++ b/src/main/java/com/can/net/protocol/ImmediateCommand.java
@@ -1,0 +1,22 @@
+package com.can.net.protocol;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Hemen yürütülebilecek komutları kapsüller.
+ */
+public final class ImmediateCommand implements CommandAction
+{
+    private final Supplier<CommandResult> executor;
+
+    public ImmediateCommand(Supplier<CommandResult> executor)
+    {
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    public Supplier<CommandResult> executor()
+    {
+        return executor;
+    }
+}

--- a/src/main/java/com/can/net/protocol/PendingStorageCommand.java
+++ b/src/main/java/com/can/net/protocol/PendingStorageCommand.java
@@ -1,0 +1,23 @@
+package com.can.net.protocol;
+
+import java.time.Duration;
+
+/**
+ * İstemciden okunacak gövde verisini tanımlar.
+ */
+public record PendingStorageCommand(String command,
+                                    String key,
+                                    int flags,
+                                    Duration ttl,
+                                    int bytes,
+                                    boolean noreply,
+                                    boolean isCas,
+                                    long casUnique)
+{
+    private static final int CRLF_LENGTH = 2;
+
+    public int totalLength()
+    {
+        return bytes + CRLF_LENGTH;
+    }
+}

--- a/src/main/java/com/can/net/protocol/StorageCommand.java
+++ b/src/main/java/com/can/net/protocol/StorageCommand.java
@@ -1,0 +1,21 @@
+package com.can.net.protocol;
+
+import java.util.Objects;
+
+/**
+ * İstemciden gövde verisi bekleyen komutları temsil eder.
+ */
+public final class StorageCommand implements CommandAction
+{
+    private final PendingStorageCommand pending;
+
+    public StorageCommand(PendingStorageCommand pending)
+    {
+        this.pending = Objects.requireNonNull(pending, "pending");
+    }
+
+    public PendingStorageCommand pending()
+    {
+        return pending;
+    }
+}

--- a/src/test/java/com/can/core/CacheSegmentTest.java
+++ b/src/test/java/com/can/core/CacheSegmentTest.java
@@ -1,5 +1,8 @@
 package com.can.core;
 
+import com.can.core.model.CacheValue;
+import com.can.core.model.CasDecision;
+import com.can.core.model.CasResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -106,8 +109,8 @@ class CacheSegmentTest
             CacheValue initial = new CacheValue(new byte[]{1}, 0);
             segment.put("a", initial);
 
-            CacheSegment.CasResult result = segment.compareAndSwap("a", existing ->
-                    CacheSegment.CasDecision.success(new CacheValue(new byte[]{2}, 5L)));
+            CasResult result = segment.compareAndSwap("a", existing ->
+                    CasDecision.success(new CacheValue(new byte[]{2}, 5L)));
 
             assertTrue(result.success());
             CacheValue stored = segment.get("a");
@@ -123,7 +126,7 @@ class CacheSegmentTest
             CacheValue initial = new CacheValue(new byte[]{1}, 0);
             segment.put("a", initial);
 
-            CacheSegment.CasResult result = segment.compareAndSwap("a", existing -> CacheSegment.CasDecision.expired());
+            CasResult result = segment.compareAndSwap("a", existing -> CasDecision.expired());
 
             assertFalse(result.success());
             assertNull(segment.get("a"));
@@ -137,7 +140,7 @@ class CacheSegmentTest
             CacheValue initial = new CacheValue(new byte[]{1}, 0);
             segment.put("a", initial);
 
-            CacheSegment.CasResult result = segment.compareAndSwap("a", existing -> null);
+            CasResult result = segment.compareAndSwap("a", existing -> null);
 
             assertFalse(result.success());
             assertNull(result.newValue());

--- a/src/test/java/com/can/core/EvictionPoliciesTest.java
+++ b/src/test/java/com/can/core/EvictionPoliciesTest.java
@@ -1,5 +1,6 @@
 package com.can.core;
 
+import com.can.core.model.CacheValue;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/can/core/ExpiringKeyTest.java
+++ b/src/test/java/com/can/core/ExpiringKeyTest.java
@@ -1,5 +1,6 @@
 package com.can.core;
 
+import com.can.core.model.ExpiringKey;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
## Summary
- move cache model records into `com.can.core.model` and adjust engine/segment logic to use the shared types
- extract hinted handoff hint implementations into `com.can.cluster.handoff`
- move memcached protocol command helpers into `com.can.net.protocol` for reuse and clarity

## Testing
- mvn test *(fails: repository dependencies unreachable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d313235e808323bd6a3aa296d88cc9