### PR TITLE
Improve cluster lifecycle animation clarity

### DIFF
--- a/docs/assets/cluster-lifecycle.svg
+++ b/docs/assets/cluster-lifecycle.svg
@@ -25,38 +25,102 @@
       .step text { font-size: 15px; }
       .step-title { font-size: 17px; font-weight: 600; }
       .step-desc { font-size: 14px; fill: #cbd5f5; }
-      .step { opacity: 0.18; transform-origin: 0 0; }
+      .step { opacity: 0.18; transform-origin: 20px 22px; }
       @keyframes spotlight {
-        0%, 11% { opacity: 1; transform: scale(1.02); }
-        16%, 100% { opacity: 0.18; transform: scale(1.0); }
+        0%, 6% { opacity: 0.18; transform: scale(1) translateY(0); }
+        10%, 16% { opacity: 0.85; transform: scale(1.02) translateY(-2px); }
+        20%, 100% { opacity: 0.22; transform: scale(1) translateY(0); }
       }
-      .step1 { animation: spotlight 24s infinite; animation-delay: 0s; }
-      .step2 { animation: spotlight 24s infinite; animation-delay: 3s; }
-      .step3 { animation: spotlight 24s infinite; animation-delay: 6s; }
-      .step4 { animation: spotlight 24s infinite; animation-delay: 9s; }
-      .step5 { animation: spotlight 24s infinite; animation-delay: 12s; }
-      .step6 { animation: spotlight 24s infinite; animation-delay: 15s; }
-      .step7 { animation: spotlight 24s infinite; animation-delay: 18s; }
-      .step8 { animation: spotlight 24s infinite; animation-delay: 21s; }
+      .step1 { animation: spotlight 24s ease-in-out infinite; animation-delay: 0s; }
+      .step2 { animation: spotlight 24s ease-in-out infinite; animation-delay: 3s; }
+      .step3 { animation: spotlight 24s ease-in-out infinite; animation-delay: 6s; }
+      .step4 { animation: spotlight 24s ease-in-out infinite; animation-delay: 9s; }
+      .step5 { animation: spotlight 24s ease-in-out infinite; animation-delay: 12s; }
+      .step6 { animation: spotlight 24s ease-in-out infinite; animation-delay: 15s; }
+      .step7 { animation: spotlight 24s ease-in-out infinite; animation-delay: 18s; }
+      .step8 { animation: spotlight 24s ease-in-out infinite; animation-delay: 21s; }
       @keyframes heartbeat {
         0%, 20%, 100% { r: 18; }
         10% { r: 22; }
       }
       .node-pulse { animation: heartbeat 3s ease-in-out infinite; }
-      @keyframes orbit {
-        0% { offset-distance: 0%; }
-        12% { offset-distance: 12%; }
-        24% { offset-distance: 24%; }
-        36% { offset-distance: 36%; }
-        48% { offset-distance: 48%; }
-        60% { offset-distance: 60%; }
-        72% { offset-distance: 72%; }
-        84% { offset-distance: 84%; }
-        100% { offset-distance: 100%; }
+      .node { filter: drop-shadow(0 0 0 rgba(56,189,248,0)); transition: filter 0.4s ease; }
+      .node-a { animation: nodeAFocus 24s ease-in-out infinite; }
+      .node-b { animation: nodeBFocus 24s ease-in-out infinite; }
+      @keyframes nodeAFocus {
+        0%, 22% { filter: drop-shadow(0 0 0 rgba(56,189,248,0)); }
+        25%, 62% { filter: drop-shadow(0 0 16px rgba(56,189,248,0.55)); }
+        65%, 100% { filter: drop-shadow(0 0 0 rgba(56,189,248,0)); }
       }
-      .packet { offset-path: path('M140 200 C 270 120 360 120 480 200 S 700 280 820 200'); offset-rotate: 0deg; animation: orbit 24s linear infinite; }
-      .packet circle { fill: #facc15; stroke: #fde68a; stroke-width: 3; }
+      @keyframes nodeBFocus {
+        0%, 6% { filter: drop-shadow(0 0 14px rgba(45,212,191,0.55)); }
+        10%, 42% { filter: drop-shadow(0 0 0 rgba(45,212,191,0)); }
+        46%, 78% { filter: drop-shadow(0 0 18px rgba(45,212,191,0.65)); }
+        82%, 100% { filter: drop-shadow(0 0 0 rgba(45,212,191,0)); }
+      }
+      .node circle { transform-box: fill-box; transform-origin: center; stroke-width: 3; }
+      .node-a circle { stroke: rgba(56,189,248,0.6); animation: nodeACircle 24s ease-in-out infinite; }
+      .node-b circle { stroke: rgba(45,212,191,0.5); animation: nodeBCircle 24s ease-in-out infinite; }
+      @keyframes nodeACircle {
+        0%, 22% { transform: scale(1); stroke-opacity: 0.1; }
+        25%, 62% { transform: scale(1.08); stroke-opacity: 1; }
+        65%, 100% { transform: scale(1); stroke-opacity: 0.1; }
+      }
+      @keyframes nodeBCircle {
+        0%, 6% { transform: scale(1.06); stroke-opacity: 0.9; }
+        10%, 42% { transform: scale(1); stroke-opacity: 0.15; }
+        46%, 78% { transform: scale(1.08); stroke-opacity: 0.95; }
+        82%, 100% { transform: scale(1); stroke-opacity: 0.15; }
+      }
+      @keyframes orbit {
+        0%, 20% { offset-distance: 0%; opacity: 0; }
+        24% { opacity: 1; }
+        36% { offset-distance: 36%; }
+        60% { offset-distance: 60%; }
+        78% { offset-distance: 84%; }
+        84%, 94% { offset-distance: 100%; opacity: 1; }
+        100% { offset-distance: 100%; opacity: 0; }
+      }
+      .packet { offset-path: path('M140 200 C 270 120 360 120 480 200 S 700 280 820 200'); offset-rotate: 0deg; animation: orbit 24s ease-in-out infinite; animation-delay: 6s; }
+      .packet circle { fill: #facc15; stroke: #fde68a; stroke-width: 3; filter: drop-shadow(0 0 8px rgba(250,204,21,0.6)); }
+      .flow { fill: none; stroke-linecap: round; stroke-dasharray: 14 16; stroke-width: 4; opacity: 0.2; animation: flowDash 24s ease-in-out infinite; }
+      .flow-client { stroke: #38bdf8; animation-delay: 6s; }
+      .flow-replica { stroke: #5eead4; animation-delay: 15s; }
+      .flow-ack { stroke: #818cf8; animation-delay: 18s; }
+      @keyframes flowDash {
+        0%, 8% { stroke-dashoffset: 120; opacity: 0; }
+        12%, 30% { stroke-dashoffset: 30; opacity: 0.85; }
+        36%, 60% { stroke-dashoffset: 0; opacity: 0.3; }
+        100% { stroke-dashoffset: -120; opacity: 0; }
+      }
       .timeline-label { font-size: 13px; fill: #94a3b8; text-transform: uppercase; letter-spacing: 0.2em; }
+      .timeline-spine { stroke: rgba(148,163,184,0.35); stroke-width: 2; stroke-linecap: round; }
+      .timeline-pointer { animation: pointerMove 24s ease-in-out infinite; transform-origin: center; }
+      .timeline-pointer circle { fill: #facc15; stroke: #fde68a; stroke-width: 3; }
+      .timeline-pointer line { stroke: rgba(250,204,21,0.45); stroke-width: 2; stroke-linecap: round; }
+      @keyframes pointerMove {
+        0%, 11% { transform: translateY(0); }
+        12.5%, 23% { transform: translateY(55px); }
+        25%, 34% { transform: translateY(110px); }
+        37.5%, 46% { transform: translateY(165px); }
+        50%, 59% { transform: translateY(220px); }
+        62.5%, 71% { transform: translateY(275px); }
+        75%, 84% { transform: translateY(330px); }
+        87.5%, 96% { transform: translateY(385px); }
+        100% { transform: translateY(0); }
+      }
+      .step-tracker { fill: rgba(250,204,21,0.08); stroke: rgba(250,204,21,0.35); stroke-width: 2; animation: trackerMove 24s ease-in-out infinite; transform-origin: 0 0; }
+      @keyframes trackerMove {
+        0%, 11% { transform: translateY(0); opacity: 0.9; }
+        12.5%, 23% { transform: translateY(55px); opacity: 0.9; }
+        25%, 34% { transform: translateY(110px); opacity: 0.9; }
+        37.5%, 46% { transform: translateY(165px); opacity: 0.9; }
+        50%, 59% { transform: translateY(220px); opacity: 0.9; }
+        62.5%, 71% { transform: translateY(275px); opacity: 0.9; }
+        75%, 84% { transform: translateY(330px); opacity: 0.9; }
+        87.5%, 96% { transform: translateY(385px); opacity: 0.9; }
+        100% { transform: translateY(0); opacity: 0.9; }
+      }
     </style>
   </defs>
   <rect fill="url(#bg)" x="0" y="0" width="960" height="540" rx="28" ry="28" />
@@ -71,23 +135,23 @@
     <text x="85" y="95" text-anchor="middle" fill="#fef9c3">SET foo ...</text>
   </g>
 
-  <g transform="translate(380, 110)">
+  <g transform="translate(380, 110)" class="node node-a">
     <rect x="0" y="0" width="180" height="250" rx="26" ry="26" fill="#172554" opacity="0.8" stroke="#38bdf8" stroke-opacity="0.45" />
     <circle cx="90" cy="60" r="34" fill="url(#node)" class="node-pulse" />
     <text x="90" y="65" text-anchor="middle" class="node-label">Node A</text>
     <text x="90" y="95" text-anchor="middle" fill="#bae6fd">Bootstrap edilmiş lider</text>
   </g>
 
-  <g transform="translate(650, 110)">
+  <g transform="translate(650, 110)" class="node node-b">
     <rect x="0" y="0" width="180" height="250" rx="26" ry="26" fill="#0f766e" opacity="0.35" stroke="#5eead4" stroke-opacity="0.4" />
     <circle cx="90" cy="60" r="34" fill="#14b8a6" class="node-pulse" />
     <text x="90" y="65" text-anchor="middle" class="node-label">Node B</text>
     <text x="90" y="95" text-anchor="middle" fill="#ccfbf1">Yeni katılan takipçi</text>
   </g>
 
-  <path d="M196 190 C 280 140 320 140 420 180" fill="none" stroke="#94a3b8" stroke-width="4" stroke-dasharray="6 10" marker-end="url(#arrow)" />
-  <path d="M470 180 Q 560 220 650 180" fill="none" stroke="#94a3b8" stroke-width="4" marker-end="url(#arrow)" />
-  <path d="M660 220 Q 720 260 780 220" fill="none" stroke="#5eead4" stroke-width="4" marker-end="url(#arrow)" />
+  <path d="M196 190 C 280 140 320 140 420 180" class="flow flow-client" marker-end="url(#arrow)" />
+  <path d="M470 180 Q 560 220 650 180" class="flow flow-replica" marker-end="url(#arrow)" />
+  <path d="M660 220 Q 720 260 780 220" class="flow flow-ack" marker-end="url(#arrow)" />
 
   <g class="packet">
     <circle r="14" />
@@ -96,6 +160,12 @@
 
   <text x="120" y="360" class="timeline-label">Yaşam döngüsü kareleri</text>
   <g transform="translate(80, 380)">
+    <line x1="-36" y1="-18" x2="-36" y2="432" class="timeline-spine" />
+    <rect x="-12" y="-12" width="832" height="56" rx="16" ry="16" class="step-tracker" />
+    <g class="timeline-pointer" transform="translate(-36, 22)">
+      <line x1="0" y1="0" x2="-24" y2="0" />
+      <circle r="7" />
+    </g>
     <g class="step step1">
       <rect x="0" y="0" width="820" height="44" rx="10" ry="10" fill="rgba(30,58,138,0.45)" />
       <text x="20" y="19" class="step-title">1. Node B kümeye merhaba der</text>


### PR DESCRIPTION
## Summary
- add node focus, flow dash, and packet glow animations to emphasise each replication phase
- introduce a moving tracker and pointer to guide viewers through the timeline steps
- retime the packet orbit to align with the client write event for better narrative flow

## Testing
- not run (doc change)

------
https://chatgpt.com/codex/tasks/task_e_68d3a96c9e388323812443b75a1150cb