### PR TITLE
Fix lambda capture of remote epoch

### DIFF
--- a/src/main/java/com/can/cluster/coordination/CoordinationService.java
+++ b/src/main/java/com/can/cluster/coordination/CoordinationService.java
@@ -212,7 +212,8 @@ public class CoordinationService implements AutoCloseable
         }
 
         try {
-            taskExecutor.execute(() -> processMembershipPacket(nodeId, host, port, remoteEpoch));
+            final long lambdaRemoteEpoch = remoteEpoch;
+            taskExecutor.execute(() -> processMembershipPacket(nodeId, host, port, lambdaRemoteEpoch));
         } catch (RejectedExecutionException e) {
             if (running) {
                 LOG.debugf("Coordination task rejected for %s:%d", nodeId, port);


### PR DESCRIPTION
## Summary
- ensure the remote epoch captured in the coordination task lambda is final by copying it to a dedicated variable

## Testing
- ./mvnw -DskipTests compile *(fails: wget cannot fetch Maven distribution in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d42a04cc74832380e5c348e7888771