### PR TITLE
Add JVM option for JDK 24 compatibility

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-opens=java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
## Summary
- add a JVM configuration flag so Maven-based commands open java.lang for Quarkus thread reset on JDK 24

## Testing
- `./mvnw -q test` *(fails: wget unable to download Maven distribution in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d430b4a6048323b1d571339e3013df