### PR TITLE
Add helper script for local performance tests

### DIFF
--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -27,6 +27,21 @@ jmeter -n \
   -JtargetPort=11211
 ```
 
+To simplify local runs there is a convenience wrapper script that automatically
+creates the results directory, wires common properties, and falls back to a
+Dockerised JMeter image if the binary is not installed:
+
+```bash
+./performance-tests/run-local.sh small
+```
+
+Pass a different profile (`small`, `medium`, `large`, or `xl`) as the first
+argument. Additional JMeter flags can be forwarded after `--`, for example:
+
+```bash
+TARGET_HOST=192.168.10.15 ./performance-tests/run-local.sh medium -- -JdurationSeconds=180
+```
+
 Commonly used override properties:
 
 | Property | Description | Default |
@@ -39,7 +54,7 @@ Commonly used override properties:
 | `keyPrefix` | Prefix used for generated cache keys. | `perf-` |
 | `payloadSize` | Size of the generated payload in bytes (plan-specific default). | varies |
 | `durationSeconds` | Total runtime of the thread group (plan-specific default). | varies |
-| `resultFile` | Output `.jtl` path for aggregated metrics. | varies |
+| `resultFile` | Output `.jtl` path for aggregated metrics. | `performance-tests/results/can-cache-<profile>.jtl` |
 
 All plans rely on a Groovy JSR223 sampler that performs a full cancached
 round-trip (set, get, delete) and validates responses. The thread groups run for

--- a/performance-tests/results/.gitignore
+++ b/performance-tests/results/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated JMeter result files
+*.jtl
+!/.gitignore

--- a/performance-tests/run-local.sh
+++ b/performance-tests/run-local.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: run-local.sh [PROFILE] [-- JMETER_ARGS...]
+
+Runs a Can Cache JMeter performance profile against a locally running instance.
+
+Profiles:
+  small   Lightweight smoke workload (default)
+  medium  Steady mid-tier workload
+  large   High concurrency workload
+  xl      Saturation-level workload
+
+Environment overrides:
+  TARGET_HOST            Target hostname/IP (default: 127.0.0.1)
+  TARGET_PORT            Target TCP port (default: 11211)
+  TTL_SECONDS            TTL in seconds for generated SET commands
+  CONNECT_TIMEOUT_MILLIS Socket connect timeout (ms)
+  READ_TIMEOUT_MILLIS    Socket read timeout (ms)
+  KEY_PREFIX             Prefix for generated cache keys
+  PAYLOAD_SIZE           Payload size in bytes (plan default if unset)
+  DURATION_SECONDS       Thread group duration override in seconds
+  RESULT_FILE            Path for the JMeter results (.jtl) file
+  JMETER_IMAGE           Docker image to use when falling back to containerised JMeter
+
+Any arguments after `--` are passed directly to the JMeter command.
+USAGE
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+profile="${1:-small}"
+if [[ $# -gt 0 && ${1} != "--" ]]; then
+  shift
+fi
+
+if [[ ${profile} == "--" ]]; then
+  profile="small"
+fi
+
+case "${profile}" in
+  small) plan="performance-tests/jmeter/can-cache-small.jmx" ;;
+  medium) plan="performance-tests/jmeter/can-cache-medium.jmx" ;;
+  large) plan="performance-tests/jmeter/can-cache-large.jmx" ;;
+  xl) plan="performance-tests/jmeter/can-cache-xl.jmx" ;;
+  *)
+    echo "Unknown profile: ${profile}" >&2
+    usage >&2
+    exit 1
+    ;;
+ esac
+
+if [[ ${1:-} == "--" ]]; then
+  shift
+fi
+
+results_dir="performance-tests/results"
+mkdir -p "${results_dir}"
+
+# Build default result file name if not provided via env or args.
+default_result_file="${results_dir}/$(basename "${plan}" .jmx).jtl"
+result_file="${RESULT_FILE:-${default_result_file}}"
+
+props=(
+  "-JtargetHost=${TARGET_HOST:-127.0.0.1}"
+  "-JtargetPort=${TARGET_PORT:-11211}"
+  "-JresultFile=${result_file}"
+)
+
+[[ -n ${TTL_SECONDS:-} ]] && props+=("-JttlSeconds=${TTL_SECONDS}")
+[[ -n ${CONNECT_TIMEOUT_MILLIS:-} ]] && props+=("-JconnectTimeoutMillis=${CONNECT_TIMEOUT_MILLIS}")
+[[ -n ${READ_TIMEOUT_MILLIS:-} ]] && props+=("-JreadTimeoutMillis=${READ_TIMEOUT_MILLIS}")
+[[ -n ${KEY_PREFIX:-} ]] && props+=("-JkeyPrefix=${KEY_PREFIX}")
+[[ -n ${PAYLOAD_SIZE:-} ]] && props+=("-JpayloadSize=${PAYLOAD_SIZE}")
+[[ -n ${DURATION_SECONDS:-} ]] && props+=("-JdurationSeconds=${DURATION_SECONDS}")
+
+jmeter_cmd=(jmeter -n -t "${plan}" -l "${result_file}")
+jmeter_cmd+=("${props[@]}")
+jmeter_cmd+=("$@")
+
+if command -v jmeter >/dev/null 2>&1; then
+  echo "Running JMeter locally: ${jmeter_cmd[*]}"
+  "${jmeter_cmd[@]}"
+  exit 0
+fi
+
+jmeter_image="${JMETER_IMAGE:-justb4/jmeter:5.6.2}"
+docker_cmd=(docker run --rm -v "$(pwd)":/workspace -w /workspace "${jmeter_image}" jmeter -n -t "${plan}" -l "${result_file}")
+docker_cmd+=("${props[@]}")
+
+if command -v docker >/dev/null 2>&1; then
+  echo "Local jmeter not found, using Docker image ${jmeter_image}" >&2
+  echo "Running: ${docker_cmd[*]}"
+  "${docker_cmd[@]}" "$@"
+  exit 0
+fi
+
+echo "Neither jmeter nor docker is available on PATH. Install Apache JMeter or Docker to run the plans." >&2
+exit 1


### PR DESCRIPTION
## Summary
- add a wrapper script for executing JMeter performance plans locally or via Docker
- ensure the results directory exists in the repository with appropriate ignores
- document the new helper and default result file locations in the performance test README

## Testing
- bash -n performance-tests/run-local.sh

------
https://chatgpt.com/codex/tasks/task_e_68d43215a18483239d0420c4c4998a9c