### PR TITLE
Build JMeter sampler for Java 21

### DIFF
--- a/performance-tests/java-sampler/pom.xml
+++ b/performance-tests/java-sampler/pom.xml
@@ -10,9 +10,9 @@
     <description>Java-based sampler used by the Can Cache performance test plans.</description>
 
     <properties>
-        <maven.compiler.source>24</maven.compiler.source>
-        <maven.compiler.target>24</maven.compiler.target>
-        <maven.compiler.release>24</maven.compiler.release>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
## Summary
- compile the performance test Java sampler against Java 21 so it matches the JDK level used by JMeter

## Testing
- ./mvnw -f performance-tests/java-sampler/pom.xml package *(fails: cannot download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d449db6238832398169867a5ebec09