### PR TITLE
Automatically build JMeter sampler in run script

### DIFF
--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -26,7 +26,8 @@ Build it once before running the plans and copy the resulting JAR to the JMeter 
 
 The command produces `performance-tests/java-sampler/target/can-cache-jmeter-sampler-0.0.1-SNAPSHOT.jar`.
 The helper script `performance-tests/run-local.sh` automatically wires this JAR for both local
-and Dockerised executions when it is present.
+and Dockerised executions when it is present. When the script is used it will also attempt to
+build the sampler automatically if the JAR is missing, provided the Maven wrapper is available.
 
 ## Running the plans
 


### PR DESCRIPTION
## Summary
- ensure the performance test helper script builds the Java sampler when the jar is missing
- extend the documentation to explain the automatic build behaviour

## Testing
- ./mvnw -f performance-tests/java-sampler/pom.xml -q package *(fails: wget could not fetch Apache Maven distribution because external network access is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d44c0afd4c83239dc5a7e74155d0c0