### PR TITLE
Improve run-local performance script logging

### DIFF
--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -105,9 +105,11 @@ JMETER_ADD_CLASSPATH="$(pwd)/performance-tests/java-sampler/target/can-cache-jme
   jmeter -n -t performance-tests/jmeter/can-cache-small.jmx
 ```
 
-The `run-local.sh` script checks for the JAR and automatically builds it when missing, provided the Maven wrapper is executable.
+The `run-local.sh` script checks for the JAR, automatically builds it when missing, and prints the absolute path of the
+resulting artefact so you can add it to custom JMeter setups, provided the Maven wrapper is executable.
 
-`run-local.sh` betiği JAR dosyasını denetler ve eksikse Maven wrapper çalıştırılabilir olduğu sürece otomatik olarak derler.
+`run-local.sh` betiği JAR dosyasını denetler, eksikse Maven wrapper çalıştırılabilir olduğu sürece otomatik olarak derler ve
+ortaya çıkan artefaktın mutlak yolunu özel JMeter kurulumlarına ekleyebilmeniz için gösterir.
 
 ---
 

--- a/performance-tests/run-local.sh
+++ b/performance-tests/run-local.sh
@@ -70,6 +70,9 @@ if [[ ! -f "${sampler_jar_rel}" ]]; then
   exit 1
 fi
 
+sampler_jar_abs="$(cd "$(dirname "${sampler_jar_rel}")" && pwd)/$(basename "${sampler_jar_rel}")"
+echo "Sampler JAR available at ${sampler_jar_abs}" >&2
+
 if [[ -n ${JMETER_HOME:-} ]]; then
   jmeter_home="${JMETER_HOME}"
 elif command -v jmeter >/dev/null 2>&1; then
@@ -109,8 +112,10 @@ results_dir="performance-tests/results"
 mkdir -p "${results_dir}"
 
 # Build default result file name if not provided via env or args.
-default_result_file="${results_dir}/$(basename "${plan}" .jmx).jtl"
+default_result_file="${results_dir}/$(basename "${plan}" .jmx)-$(date +%Y%m%d-%H%M%S).jtl"
 result_file="${RESULT_FILE:-${default_result_file}}"
+
+echo "Results will be written to ${result_file}" >&2
 
 props=(
   "-JtargetHost=${TARGET_HOST:-127.0.0.1}"
@@ -131,3 +136,5 @@ jmeter_cmd+=("$@")
 
 echo "Running JMeter locally: ${jmeter_cmd[*]}"
 "${jmeter_cmd[@]}"
+
+echo "JMeter execution finished. Results available at ${result_file}" >&2


### PR DESCRIPTION
## Summary
- print the absolute path of the freshly built JMeter sampler JAR when running performance-tests/run-local.sh
- add timestamped default result filenames and log the destination for generated JTL files
- document the new behaviour in the performance test README

## Testing
- ⚠️ ./mvnw -q -f performance-tests/java-sampler/pom.xml package *(fails: network access to Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d455f306588323b0bb199b435f0691