### PR TITLE
Introduce Cancached protocol data model

### DIFF
--- a/src/main/java/com/can/net/CanCachedServer.java
+++ b/src/main/java/com/can/net/CanCachedServer.java
@@ -4,6 +4,7 @@ import com.can.cluster.ClusterClient;
 import com.can.config.AppProperties;
 import com.can.core.CacheEngine;
 import com.can.core.StoredValueCodec;
+import com.can.net.protocol.CancachedProtocol;
 import com.can.net.protocol.CommandAction;
 import com.can.net.protocol.CommandResult;
 import com.can.net.protocol.ImmediateCommand;
@@ -210,7 +211,8 @@ public class CanCachedServer implements AutoCloseable
         }
 
         Duration ttl = parseExpiration(exptime);
-        return new StorageCommand(new PendingStorageCommand(command, parts[1], flags, ttl, (int) bytes, noreply, isCas, casUnique));
+        CancachedProtocol.CacheRequest request = new CancachedProtocol.CacheRequest(command, parts[1], flags, ttl, (int) bytes, noreply, isCas, casUnique);
+        return new StorageCommand(new CancachedProtocol(command, request));
     }
 
     private CommandResult handleStoragePayload(PendingStorageCommand pending, Buffer payload)

--- a/src/main/java/com/can/net/protocol/CancachedProtocol.java
+++ b/src/main/java/com/can/net/protocol/CancachedProtocol.java
@@ -1,0 +1,54 @@
+package com.can.net.protocol;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Cancached sunucusunun kabullendiği protokolü temsil eden veri sınıfıdır.
+ *
+ * <p>Şu anda yalnızca storage komutlarının ayrıştırılması için kullanılmaktadır
+ * ancak ileride farklı protokol türlerini genişletebilmek için isimlendirilmiş
+ * bir veri modeli sağlar.</p>
+ */
+public record CancachedProtocol(String name, CacheRequest cacheRequest)
+{
+    public CancachedProtocol
+    {
+        this.name = Objects.requireNonNull(name, "name");
+        // cacheRequest null olabilir; bu durumda protokol yalnızca komut ismi ile temsil edilir.
+        if (cacheRequest != null && !Objects.equals(cacheRequest.command(), name)) {
+            throw new IllegalArgumentException("Cache request command must match protocol name");
+        }
+    }
+
+    public boolean expectsCacheRequest()
+    {
+        return cacheRequest != null;
+    }
+
+    public record CacheRequest(String command,
+                               String key,
+                               int flags,
+                               Duration ttl,
+                               int bytes,
+                               boolean noreply,
+                               boolean cas,
+                               long casUnique)
+    {
+        private static final int CRLF_LENGTH = 2;
+
+        public CacheRequest
+        {
+            this.command = Objects.requireNonNull(command, "command");
+            this.key = Objects.requireNonNull(key, "key");
+            if (bytes < 0) {
+                throw new IllegalArgumentException("bytes must be greater than or equal to 0");
+            }
+        }
+
+        public int totalLength()
+        {
+            return bytes + CRLF_LENGTH;
+        }
+    }
+}

--- a/src/main/java/com/can/net/protocol/PendingStorageCommand.java
+++ b/src/main/java/com/can/net/protocol/PendingStorageCommand.java
@@ -1,23 +1,72 @@
 package com.can.net.protocol;
 
 import java.time.Duration;
+import java.util.Objects;
 
 /**
  * İstemciden okunacak gövde verisini tanımlar.
  */
-public record PendingStorageCommand(String command,
-                                    String key,
-                                    int flags,
-                                    Duration ttl,
-                                    int bytes,
-                                    boolean noreply,
-                                    boolean isCas,
-                                    long casUnique)
+public record PendingStorageCommand(CancachedProtocol.CacheRequest request)
 {
-    private static final int CRLF_LENGTH = 2;
+    public PendingStorageCommand
+    {
+        this.request = Objects.requireNonNull(request, "request");
+    }
+
+    public PendingStorageCommand(String command,
+                                 String key,
+                                 int flags,
+                                 Duration ttl,
+                                 int bytes,
+                                 boolean noreply,
+                                 boolean isCas,
+                                 long casUnique)
+    {
+        this(new CancachedProtocol.CacheRequest(command, key, flags, ttl, bytes, noreply, isCas, casUnique));
+    }
+
+    public String command()
+    {
+        return request.command();
+    }
+
+    public String key()
+    {
+        return request.key();
+    }
+
+    public int flags()
+    {
+        return request.flags();
+    }
+
+    public Duration ttl()
+    {
+        return request.ttl();
+    }
+
+    public int bytes()
+    {
+        return request.bytes();
+    }
+
+    public boolean noreply()
+    {
+        return request.noreply();
+    }
+
+    public boolean isCas()
+    {
+        return request.cas();
+    }
+
+    public long casUnique()
+    {
+        return request.casUnique();
+    }
 
     public int totalLength()
     {
-        return bytes + CRLF_LENGTH;
+        return request.totalLength();
     }
 }

--- a/src/main/java/com/can/net/protocol/StorageCommand.java
+++ b/src/main/java/com/can/net/protocol/StorageCommand.java
@@ -7,11 +7,27 @@ import java.util.Objects;
  */
 public final class StorageCommand implements CommandAction
 {
+    private final CancachedProtocol protocol;
+
     private final PendingStorageCommand pending;
+
+    public StorageCommand(CancachedProtocol protocol)
+    {
+        this.protocol = Objects.requireNonNull(protocol, "protocol");
+        if (!protocol.expectsCacheRequest()) {
+            throw new IllegalArgumentException("Protocol does not describe a cache request payload");
+        }
+        this.pending = new PendingStorageCommand(protocol.cacheRequest());
+    }
 
     public StorageCommand(PendingStorageCommand pending)
     {
-        this.pending = Objects.requireNonNull(pending, "pending");
+        this(new CancachedProtocol(pending.command(), pending.request()));
+    }
+
+    public CancachedProtocol protocol()
+    {
+        return protocol;
     }
 
     public PendingStorageCommand pending()


### PR DESCRIPTION
## Summary
- add a dedicated `CancachedProtocol` record to describe the cache protocol and request payloads
- update storage command handling to flow through the new protocol model while keeping existing command behaviour

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Maven wrapper cannot download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d678017a748323807d4bca571db5d5