### PR TITLE
Rename unit test names to English

### DIFF
--- a/src/test/java/com/can/cluster/ClusterStateTest.java
+++ b/src/test/java/com/can/cluster/ClusterStateTest.java
@@ -22,11 +22,11 @@ class ClusterStateTest
     }
 
     @Nested
-    class KimlikBilgisi
+    class IdentityInformation
     {
         // Bu test yerel düğüm kimliğinin ve bayt temsilinin doğru döndüğünü doğrular.
         @Test
-        void local_node_id_ve_baytlarini_doner()
+        void local_node_id_and_bytes_are_returned()
         {
             assertEquals("node-1", state.localNodeId());
             assertArrayEquals("node-1".getBytes(StandardCharsets.UTF_8), state.localNodeIdBytes());
@@ -34,11 +34,11 @@ class ClusterStateTest
     }
 
     @Nested
-    class EpochYonetimi
+    class EpochManagement
     {
         // Bu test bumpEpoch çağrısının değer artırdığını ve metrikleri güncellediğini gösterir.
         @Test
-        void bump_epoch_degeri_arttirir()
+        void bump_epoch_increments_value()
         {
             long initial = state.currentEpoch();
             long next = state.bumpEpoch();
@@ -48,7 +48,7 @@ class ClusterStateTest
 
         // Bu test uzaktan gelen daha büyük epoch değerinin benimsendiğini doğrular.
         @Test
-        void observe_epoch_daha_buyuk_degeri_kabul_eder()
+        void observe_epoch_accepts_higher_value()
         {
             long expected = state.currentEpoch() + 5;
             state.observeEpoch(expected);
@@ -58,7 +58,7 @@ class ClusterStateTest
 
         // Bu test daha küçük veya geçersiz epoch değerlerinin dikkate alınmadığını doğrular.
         @Test
-        void observe_epoch_kucuk_degerleri_yoksayar()
+        void observe_epoch_ignores_lower_values()
         {
             long initial = state.currentEpoch();
             state.observeEpoch(initial - 1);

--- a/src/test/java/com/can/cluster/ConsistentHashRingTest.java
+++ b/src/test/java/com/can/cluster/ConsistentHashRingTest.java
@@ -20,11 +20,11 @@ class ConsistentHashRingTest
     }
 
     @Nested
-    class NodeYonetimi
+    class NodeManagement
     {
         // Bu test düğüm eklendiğinde benzersiz liste olarak döndürüldüğünü doğrular.
         @Test
-        void add_node_benzersiz_liste_doner()
+        void add_node_returns_unique_list()
         {
             ring.addNode("A", bytes("A"));
             ring.addNode("B", bytes("B"));
@@ -33,7 +33,7 @@ class ConsistentHashRingTest
 
         // Bu test düğüm kaldırıldığında replika listesinden çıkarıldığını gösterir.
         @Test
-        void remove_node_tum_sanal_dugumleri_temizler()
+        void remove_node_clears_virtual_nodes()
         {
             ring.addNode("A", bytes("A"));
             ring.addNode("B", bytes("B"));
@@ -44,11 +44,11 @@ class ConsistentHashRingTest
     }
 
     @Nested
-    class ReplicaSecimi
+    class ReplicaSelection
     {
         // Bu test replikaların belirlenen sırada ve tekrar etmeden döndüğünü doğrular.
         @Test
-        void get_replicas_belirlenen_dugumleri_siralar()
+        void get_replicas_returns_requested_nodes_in_order()
         {
             ring.addNode("A", bytes("A"));
             ring.addNode("B", bytes("B"));
@@ -59,7 +59,7 @@ class ConsistentHashRingTest
 
         // Bu test istenen replika sayısından az düğüm olduğunda mevcut düğümlerin döndürüldüğünü gösterir.
         @Test
-        void get_replicas_dugum_sayisindan_buyuk_istegi_kirar()
+        void get_replicas_limits_to_available_nodes()
         {
             ring.addNode("A", bytes("A"));
             ring.addNode("B", bytes("B"));
@@ -69,7 +69,7 @@ class ConsistentHashRingTest
 
         // Bu test boş halkada replika isteğinin boş liste ürettiğini doğrular.
         @Test
-        void get_replicas_bos_halkada_bos_liste_doner()
+        void get_replicas_returns_empty_list_for_empty_ring()
         {
             assertTrue(ring.getReplicas(bytes("key"), 2).isEmpty());
         }

--- a/src/test/java/com/can/cluster/HintedHandoffServiceTest.java
+++ b/src/test/java/com/can/cluster/HintedHandoffServiceTest.java
@@ -24,11 +24,11 @@ class HintedHandoffServiceTest
     }
 
     @Nested
-    class KaydetmeIslemleri
+    class RecordingOperations
     {
         // Bu test set ipucunun kuyruğa eklendiğini ve metriklerin arttığını doğrular.
         @Test
-        void record_set_kuyrugu_arttirir()
+        void record_set_enqueues_hint()
         {
             service.recordSet("node", "key", "value", Duration.ofSeconds(1));
             assertEquals(1, service.pendingFor("node"));
@@ -37,7 +37,7 @@ class HintedHandoffServiceTest
 
         // Bu test delete ve CAS ipuçlarının da kuyruğa eklendiğini gösterir.
         @Test
-        void record_delete_ve_cas_kuyrugu_doldurur()
+        void record_delete_and_cas_enqueue_hints()
         {
             service.recordDelete("node", "key");
             service.recordCas("node", "key", "value", 5L, Duration.ZERO);
@@ -46,11 +46,11 @@ class HintedHandoffServiceTest
     }
 
     @Nested
-    class ReplayIslemleri
+    class ReplayOperations
     {
         // Bu test başarılı ipuçlarının yeniden oynatılarak kuyruktan silindiğini doğrular.
         @Test
-        void replay_basarili_islemleri_temizler()
+        void replay_cleans_up_successful_hints()
         {
             service.recordSet("node", "key", "value", Duration.ofSeconds(1));
             service.recordDelete("node", "key");
@@ -65,7 +65,7 @@ class HintedHandoffServiceTest
 
         // Bu test yeniden oynatma başarısız olduğunda ipucunun kuyrukta kaldığını ve hata metriğinin arttığını doğrular.
         @Test
-        void replay_basarisiz_olunca_ipucu_kalir()
+        void replay_leaves_hint_on_failure()
         {
             service.recordSet("node", "key", "value", Duration.ZERO);
             node.throwNextSet();

--- a/src/test/java/com/can/codec/CodecsTest.java
+++ b/src/test/java/com/can/codec/CodecsTest.java
@@ -10,25 +10,25 @@ import static org.junit.jupiter.api.Assertions.*;
 class CodecsTest
 {
     @Nested
-    class StringCodecDavranisi
+    class StringCodecBehavior
     {
         // Bu test null değerin boş diziye dönüştürüldüğünü doğrular.
         @Test
-        void encode_null_bos_dizi_doner()
+        void encode_null_returns_empty_array()
         {
             assertArrayEquals(new byte[0], StringCodec.UTF8.encode(null));
         }
 
         // Bu test boş dizinin boş stringe çözüldüğünü gösterir.
         @Test
-        void decode_bos_dizi_bos_string_doner()
+        void decode_empty_array_returns_empty_string()
         {
             assertEquals("", StringCodec.UTF8.decode(new byte[0]));
         }
 
         // Bu test encode-decode işleminin yuvarlak tur sağladığını doğrular.
         @Test
-        void encode_decode_tam_tur_calismaya_devam_eder()
+        void encode_decode_performs_round_trip()
         {
             String original = "Merhaba dünya";
             byte[] encoded = StringCodec.UTF8.encode(original);
@@ -37,11 +37,11 @@ class CodecsTest
     }
 
     @Nested
-    class JavaSerializerCodecDavranisi
+    class JavaSerializerCodecBehavior
     {
         // Bu test serileştirilebilir nesnenin aynı içerikle geri döndüğünü doğrular.
         @Test
-        void serialize_ve_deserialize_ayni_nesneyi_doner()
+        void serialize_and_deserialize_return_same_object()
         {
             JavaSerializerCodec<Sample> codec = new JavaSerializerCodec<>();
             Sample original = new Sample("data", 42);
@@ -52,7 +52,7 @@ class CodecsTest
 
         // Bu test boş diziden null döndüğünü gösterir.
         @Test
-        void decode_bos_dizi_null_doner()
+        void decode_empty_array_returns_null()
         {
             JavaSerializerCodec<Sample> codec = new JavaSerializerCodec<>();
             assertNull(codec.decode(new byte[0]));

--- a/src/test/java/com/can/core/CacheSegmentTest.java
+++ b/src/test/java/com/can/core/CacheSegmentTest.java
@@ -28,11 +28,11 @@ class CacheSegmentTest
     }
 
     @Nested
-    class PutIslemleri
+    class PutOperations
     {
         // Bu test politika izin verdiğinde yeni girdinin eklendiğini doğrular.
         @Test
-        void put_yeni_anahtar_onaylandiginda_basarili_olur()
+        void put_succeeds_when_key_is_admitted()
         {
             assertTrue(segment.put("a", value("1")));
             assertEquals(1, segment.size());
@@ -41,7 +41,7 @@ class CacheSegmentTest
 
         // Bu test politika reddettiğinde put çağrısının başarısız döndüğünü gösterir.
         @Test
-        void put_politika_reddederse_false_doner()
+        void put_returns_false_when_policy_rejects()
         {
             policy.rejectNext();
             assertFalse(segment.put("b", value("2")));
@@ -50,7 +50,7 @@ class CacheSegmentTest
 
         // Bu test mevcut anahtar tekrar yazıldığında değerin güncellendiğini ispatlar.
         @Test
-        void put_mevcut_anahtari_gunceller()
+        void put_updates_existing_key()
         {
             assertTrue(segment.put("a", value("1")));
             assertTrue(segment.put("a", value("2")));
@@ -59,7 +59,7 @@ class CacheSegmentTest
 
         // Bu test kurban anahtar belirlendiğinde dinleyicinin bilgilendirildiğini doğrular.
         @Test
-        void put_victim_belirlenince_dinleyici_tetiklenir()
+        void put_notifies_listener_when_victim_selected()
         {
             assertTrue(segment.put("a", value("1")));
             assertTrue(segment.put("b", value("2")));
@@ -71,7 +71,7 @@ class CacheSegmentTest
 
         // Bu test force eklemenin kapasite dolu olsa bile en eski girdiyi attığını gösterir.
         @Test
-        void put_force_dolulukta_en_eskisini_siler()
+        void put_force_evicts_oldest_when_full()
         {
             assertTrue(segment.put("a", value("1")));
             assertTrue(segment.put("b", value("2")));
@@ -82,11 +82,11 @@ class CacheSegmentTest
     }
 
     @Nested
-    class SilmeIslemleri
+    class RemoveOperations
     {
         // Bu test remove çağrısının değeri döndürüp politikayı bilgilendirdiğini doğrular.
         @Test
-        void remove_varsa_degeri_doner()
+        void remove_returns_value_when_present()
         {
             assertTrue(segment.put("a", value("1")));
             CacheValue removed = segment.remove("a");
@@ -96,7 +96,7 @@ class CacheSegmentTest
 
         // Bu test expireAt eşleştiğinde koşullu silmenin başarılı olduğunu ispatlar.
         @Test
-        void remove_if_matches_zaman_eslesirse_siler()
+        void remove_if_matches_deletes_when_timestamp_matches()
         {
             assertTrue(segment.put("a", new CacheValue("v".getBytes(StandardCharsets.UTF_8), 123L)));
             assertFalse(segment.removeIfMatches("a", 999L));
@@ -106,7 +106,7 @@ class CacheSegmentTest
 
         // Bu test clear çağrısının tüm girdileri temizlediğini doğrular.
         @Test
-        void clear_tum_girdileri_temizler()
+        void clear_removes_all_entries()
         {
             assertTrue(segment.put("a", value("1")));
             assertTrue(segment.put("b", value("2")));
@@ -117,11 +117,11 @@ class CacheSegmentTest
     }
 
     @Nested
-    class CasIslemleri
+    class CasOperations
     {
         // Bu test CAS kararı başarı olduğunda yeni değerin yazıldığını gösterir.
         @Test
-        void compare_and_swap_basarili_oldugunda_yeni_deger_yazilir()
+        void compare_and_swap_writes_new_value_on_success()
         {
             assertTrue(segment.put("a", value("old")));
             var result = segment.compareAndSwap("a", existing -> CasDecision.success(value("new")));
@@ -132,7 +132,7 @@ class CacheSegmentTest
 
         // Bu test CAS kararı mevcut girdiyi kaldırdığında dinleyicinin çağrıldığını doğrular.
         @Test
-        void compare_and_swap_silme_karari_alirsa_dinleyici_tetiklenir()
+        void compare_and_swap_notifies_listener_on_delete()
         {
             assertTrue(segment.put("a", value("old")));
             var result = segment.compareAndSwap("a", existing -> CasDecision.expired());
@@ -143,11 +143,11 @@ class CacheSegmentTest
     }
 
     @Nested
-    class DigerIslemler
+    class OtherOperations
     {
         // Bu test forEach çağrısının snapshot üzerinden güvenle çalıştığını doğrular.
         @Test
-        void for_each_snapshot_uzerinden_calismaya_devam_eder()
+        void for_each_continues_operating_on_snapshot()
         {
             assertTrue(segment.put("a", value("1")));
             assertTrue(segment.put("b", value("2")));

--- a/src/test/java/com/can/core/EvictionPoliciesTest.java
+++ b/src/test/java/com/can/core/EvictionPoliciesTest.java
@@ -11,11 +11,11 @@ import static org.junit.jupiter.api.Assertions.*;
 class EvictionPoliciesTest
 {
     @Nested
-    class TipCozumleme
+    class TypeResolution
     {
         // Bu test yapılandırma değeri boş olduğunda LRU politikasının seçildiğini doğrular.
         @Test
-        void from_config_bos_deger_lru_doner()
+        void from_config_returns_lru_for_blank_value()
         {
             assertEquals(EvictionPolicyType.LRU, EvictionPolicyType.fromConfig(null));
             assertEquals(EvictionPolicyType.LRU, EvictionPolicyType.fromConfig(" "));
@@ -23,7 +23,7 @@ class EvictionPoliciesTest
 
         // Bu test farklı yazımlarla verilen TinyLFU değerinin doğru çözümlendiğini gösterir.
         @Test
-        void from_config_tiny_lfu_normalize_edilir()
+        void from_config_normalizes_tiny_lfu()
         {
             assertEquals(EvictionPolicyType.TINY_LFU, EvictionPolicyType.fromConfig("tiny-lfu"));
             assertEquals(EvictionPolicyType.TINY_LFU, EvictionPolicyType.fromConfig("Tiny_Lfu"));
@@ -31,18 +31,18 @@ class EvictionPoliciesTest
 
         // Bu test bilinmeyen politika değerinde istisna fırlatıldığını doğrular.
         @Test
-        void from_config_bilinmeyen_deger_hata_firlatir()
+        void from_config_throws_for_unknown_value()
         {
             assertThrows(IllegalArgumentException.class, () -> EvictionPolicyType.fromConfig("unknown"));
         }
     }
 
     @Nested
-    class LruDavranisi
+    class LruBehavior
     {
         // Bu test kapasite dolmadığında yeni anahtarın doğrudan kabul edildiğini gösterir.
         @Test
-        void lru_bos_kapasitede_adayi_kabul_eder()
+        void lru_admits_candidate_when_capacity_available()
         {
             LruEvictionPolicy<String> policy = new LruEvictionPolicy<>();
             LinkedHashMap<String, CacheValue> map = new LinkedHashMap<>();
@@ -53,7 +53,7 @@ class EvictionPoliciesTest
 
         // Bu test kapasite dolduğunda en eski girdinin kurban seçildiğini doğrular.
         @Test
-        void lru_dolulukta_en_eskisini_kurban_secer()
+        void lru_evicts_oldest_when_full()
         {
             LruEvictionPolicy<String> policy = new LruEvictionPolicy<>();
             LinkedHashMap<String, CacheValue> map = new LinkedHashMap<>();
@@ -66,11 +66,11 @@ class EvictionPoliciesTest
     }
 
     @Nested
-    class TinyLfuDavranisi
+    class TinyLfuBehavior
     {
         // Bu test boş kapasitede TinyLFU'nun adayı kabul ettiğini doğrular.
         @Test
-        void tiny_lfu_bos_kapasitede_adayi_kabul_eder()
+        void tiny_lfu_admits_candidate_with_free_capacity()
         {
             TinyLfuEvictionPolicy<String> policy = new TinyLfuEvictionPolicy<>(2);
             LinkedHashMap<String, CacheValue> map = new LinkedHashMap<>();
@@ -81,7 +81,7 @@ class EvictionPoliciesTest
 
         // Bu test adayın frekansı kurbandan yüksek olduğunda kabul edildiğini gösterir.
         @Test
-        void tiny_lfu_yuksek_frekansli_adayi_kabul_eder()
+        void tiny_lfu_admits_candidate_with_higher_frequency()
         {
             TinyLfuEvictionPolicy<String> policy = new TinyLfuEvictionPolicy<>(1);
             LinkedHashMap<String, CacheValue> map = new LinkedHashMap<>();
@@ -97,7 +97,7 @@ class EvictionPoliciesTest
 
         // Bu test adayın frekansı düşük olduğunda reddedildiğini doğrular.
         @Test
-        void tiny_lfu_dusuk_frekansli_adayi_reddeder()
+        void tiny_lfu_rejects_low_frequency_candidate()
         {
             TinyLfuEvictionPolicy<String> policy = new TinyLfuEvictionPolicy<>(1);
             LinkedHashMap<String, CacheValue> map = new LinkedHashMap<>();

--- a/src/test/java/com/can/core/ExpiringKeyTest.java
+++ b/src/test/java/com/can/core/ExpiringKeyTest.java
@@ -11,11 +11,11 @@ import static org.junit.jupiter.api.Assertions.*;
 class ExpiringKeyTest
 {
     @Nested
-    class ZamanDavranisi
+    class TimingBehavior
     {
         // Bu test gelecekteki zamanlar için bekleme süresinin pozitif olduğunu doğrular.
         @Test
-        void get_delay_gelecek_zaman_icin_pozitif_doner()
+        void get_delay_returns_positive_for_future_time()
         {
             long expireAt = System.currentTimeMillis() + 200L;
             ExpiringKey key = new ExpiringKey("k", 0, expireAt);
@@ -25,7 +25,7 @@ class ExpiringKeyTest
 
         // Bu test compareTo'nun en erken süresi olan anahtarı önce sıraladığını gösterir.
         @Test
-        void compare_to_sureye_gore_siralama_yapar()
+        void compare_to_orders_by_expiration_time()
         {
             long now = System.currentTimeMillis();
             ExpiringKey early = new ExpiringKey("a", 0, now + 10);

--- a/src/test/java/com/can/core/StoredValueCodecTest.java
+++ b/src/test/java/com/can/core/StoredValueCodecTest.java
@@ -10,11 +10,11 @@ import static org.junit.jupiter.api.Assertions.*;
 class StoredValueCodecTest
 {
     @Nested
-    class DecodeDavranisi
+    class DecodeBehavior
     {
         // Bu test encode edilmiş verinin çözümlenerek aynı alanları ürettiğini doğrular.
         @Test
-        void decode_gecerli_veriyi_cozer()
+        void decode_decodes_valid_value()
         {
             StoredValueCodec.StoredValue stored = new StoredValueCodec.StoredValue(
                     "veri".getBytes(StandardCharsets.UTF_8), 7, 99L, 1_234L);
@@ -29,7 +29,7 @@ class StoredValueCodecTest
 
         // Bu test bozuk Base64 girdisinin legacy formatı olarak ele alındığını gösterir.
         @Test
-        void decode_hatali_veriyi_legacy_olarak_yorumlar()
+        void decode_interprets_invalid_value_as_legacy()
         {
             StoredValueCodec.StoredValue decoded = StoredValueCodec.decode("not-base64");
             assertArrayEquals("not-base64".getBytes(StandardCharsets.UTF_8), decoded.value());
@@ -40,7 +40,7 @@ class StoredValueCodecTest
 
         // Bu test expireAt geçmiş olduğunda expired metodunun true döndüğünü doğrular.
         @Test
-        void expired_metodu_suresi_gecmis_degerde_true_doner()
+        void expired_returns_true_for_past_value()
         {
             long past = System.currentTimeMillis() - 1_000L;
             StoredValueCodec.StoredValue stored = new StoredValueCodec.StoredValue(
@@ -50,11 +50,11 @@ class StoredValueCodecTest
     }
 
     @Nested
-    class MutasyonDavranisi
+    class MutationBehavior
     {
         // Bu test withValue çağrısının yeni değer ve CAS ürettiğini gösterir.
         @Test
-        void with_value_yeni_deger_ve_cas_atar()
+        void with_value_updates_value_and_cas()
         {
             StoredValueCodec.StoredValue stored = new StoredValueCodec.StoredValue(
                     "eski".getBytes(StandardCharsets.UTF_8), 2, 10L, 0L);
@@ -67,7 +67,7 @@ class StoredValueCodecTest
 
         // Bu test withMeta çağrısının tüm alanları güncellediğini doğrular.
         @Test
-        void with_meta_tum_alanlari_gunceller()
+        void with_meta_updates_all_fields()
         {
             StoredValueCodec.StoredValue stored = new StoredValueCodec.StoredValue(
                     "veri".getBytes(StandardCharsets.UTF_8), 1, 3L, 4L);
@@ -81,7 +81,7 @@ class StoredValueCodecTest
 
         // Bu test withExpireAt çağrısının yalnızca süre bilgisini güncellediğini gösterir.
         @Test
-        void with_expire_at_sadece_sureyi_degistirir()
+        void with_expire_at_only_changes_expiration()
         {
             StoredValueCodec.StoredValue stored = new StoredValueCodec.StoredValue(
                     "veri".getBytes(StandardCharsets.UTF_8), 1, 3L, 4L);

--- a/src/test/java/com/can/metric/MetricsComponentsTest.java
+++ b/src/test/java/com/can/metric/MetricsComponentsTest.java
@@ -10,11 +10,11 @@ import static org.junit.jupiter.api.Assertions.*;
 class MetricsComponentsTest
 {
     @Nested
-    class CounterDavranisi
+    class CounterBehavior
     {
         // Bu test sayaç artışının ve toplamanın değeri doğru güncellediğini doğrular.
         @Test
-        void counter_artis_ve_toplama_yapar()
+        void counter_handles_increment_and_add()
         {
             Counter counter = new Counter("hits");
             counter.inc();
@@ -25,11 +25,11 @@ class MetricsComponentsTest
     }
 
     @Nested
-    class TimerDavranisi
+    class TimerBehavior
     {
         // Bu test süre kayıtlarının istatistiklere yansıtıldığını gösterir.
         @Test
-        void timer_sureleri_toplayip_istatistik_uretir()
+        void timer_aggregates_durations_into_statistics()
         {
             Timer timer = new Timer("latency", 128);
             timer.record(1_000);
@@ -45,11 +45,11 @@ class MetricsComponentsTest
     }
 
     @Nested
-    class RegistryDavranisi
+    class RegistryBehavior
     {
         // Bu test aynı isim için aynı sayaç ve zamanlayıcının döndüğünü doğrular.
         @Test
-        void registry_ayni_adi_paylasan_nesneleri_yeniden_kullanir()
+        void registry_reuses_components_with_same_name()
         {
             MetricsRegistry registry = new MetricsRegistry();
             Counter firstCounter = registry.counter("requests");
@@ -64,11 +64,11 @@ class MetricsComponentsTest
     }
 
     @Nested
-    class ReporterDavranisi
+    class ReporterBehavior
     {
         // Bu test geçerli aralıkla başlatılan raporlama görevlerinin çalıştığını doğrular.
         @Test
-        void reporter_gecerli_aralikla_calisir() throws Exception
+        void reporter_runs_with_valid_interval() throws Exception
         {
             MetricsRegistry registry = new MetricsRegistry();
             Vertx vertx = Vertx.vertx();
@@ -90,7 +90,7 @@ class MetricsComponentsTest
 
         // Bu test geçersiz aralıkta raporlayıcının başlamadığını gösterir.
         @Test
-        void reporter_gecersiz_araligi_yoksayar()
+        void reporter_ignores_invalid_interval()
         {
             MetricsRegistry registry = new MetricsRegistry();
             Vertx vertx = Vertx.vertx();


### PR DESCRIPTION
## Summary
- rename unit test method and nested class names from Turkish to English across cache, cluster, codec, and metric test suites

## Testing
- `./mvnw -q test` *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f44050ac8323a32923f3e3d09e63