### PR TITLE
Ensure runnable jar packaging for Quarkus run

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,3 +37,6 @@ quarkus.log.file.path=logs/app.log
 quarkus.log.file.rotation.max-file-size=10M
 quarkus.log.file.rotation.max-backup-index=7
 quarkus.vertx.prefer-native-transport=true
+
+# Ensure Quarkus always produces the runnable JAR that `quarkus:run` relies on.
+quarkus.package.jar.enabled=true


### PR DESCRIPTION
## Summary
- enable the runnable JAR packaging in `application.properties` so `mvn quarkus:run` always produces the expected launcher

## Testing
- mvn package *(fails: Maven Central returns 403 in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d704de74cc832395ffe9b509e9e92e