### PR TITLE
Ensure quarkus:run builds mutable jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>3.28.1</quarkus.platform.version>
+        <quarkus.package.type>mutable-jar</quarkus.package.type>
+        <quarkus.package.jar.enabled>true</quarkus.package.jar.enabled>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <maven.compiler.release>24</maven.compiler.release>
         <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,3 +40,4 @@ quarkus.vertx.prefer-native-transport=true
 
 # Ensure Quarkus always produces the runnable JAR that `quarkus:run` relies on.
 quarkus.package.jar.enabled=true
+quarkus.package.type=mutable-jar


### PR DESCRIPTION
## Summary
- force Quarkus builds to use mutable-jar packaging so the quarkus:run goal always has a runnable artifact
- document the packaging mode in application.properties alongside the existing jar toggle

## Testing
- not run (offline environment)


------
https://chatgpt.com/codex/tasks/task_e_68d70630f7dc832394ac98d1fcbaf3c5