### PR TITLE
Update Quarkus packaging configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>3.28.1</quarkus.platform.version>
-        <quarkus.package.type>mutable-jar</quarkus.package.type>
         <quarkus.package.jar.enabled>true</quarkus.package.jar.enabled>
+        <quarkus.package.jar.type>fast-jar</quarkus.package.jar.type>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <maven.compiler.release>24</maven.compiler.release>
         <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>


### PR DESCRIPTION
## Summary
- replace the deprecated `quarkus.package.type` property with the supported `quarkus.package.jar.type=fast-jar` so the build produces the expected runnable jar

## Testing
- not run (Maven Central access is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d707aa6eec8323892b04652863d8fd