### PR TITLE
Replace protocol literals with NodeProtocol constants

### DIFF
--- a/src/main/java/com/can/constants/NodeProtocol.java
+++ b/src/main/java/com/can/constants/NodeProtocol.java
@@ -2,14 +2,54 @@ package com.can.constants;
 
 public final class NodeProtocol
 {
+    // 'S' komutu, remote node'a gelen veriyi SET işlemi ile saklamak için gönderilir.
     public static final byte CMD_SET = 'S';
+
+    // 'X' komutu, Compare-And-Swap (CAS) operasyonu için kullanılır.
     public static final byte CMD_CAS = 'X';
+
+    // 'G' komutu, istenen anahtardaki veriyi GET isteği olarak talep eder.
     public static final byte CMD_GET = 'G';
+
+    // 'D' komutu, belirtilen anahtarı DELETE isteği ile siler.
     public static final byte CMD_DELETE = 'D';
+
+    // 'C' komutu, node üzerindeki tüm veriyi CLEAR işlemi ile temizler.
     public static final byte CMD_CLEAR = 'C';
+
+    // 'J' komutu, yeni bir node'un kümeye JOIN el sıkışmasını başlatmasını sağlar.
+    public static final byte CMD_JOIN = 'J';
+
+    // 'R' komutu, bir node'dan tam veri akışı (STREAM) talep eder.
+    public static final byte CMD_STREAM = 'R';
+
+    // 'H' komutu, uzak nodun anti-entropy Digest değerini istemek için gönderilir.
+    public static final byte CMD_DIGEST = 'H';
+
+    // 'O' yanıtı, isteğin başarılı olduğunu (OK) belirtir.
     public static final byte RESP_OK = 'O';
+
+    // 'H' yanıtı, GET sonucunda verinin bulunduğunu (HIT) bildirir.
     public static final byte RESP_HIT = 'H';
+
+    // 'M' yanıtı, GET sonucunda verinin bulunamadığını (MISS) gösterir.
     public static final byte RESP_MISS = 'M';
+
+    // 'T' yanıtı, boolean dönen işlemlerde TRUE sonucunu ifade eder.
     public static final byte RESP_TRUE = 'T';
+
+    // 'F' yanıtı, boolean dönen işlemlerde FALSE sonucunu ifade eder.
     public static final byte RESP_FALSE = 'F';
+
+    // 'A' yanıtı, join el sıkışmasının ACCEPT edildiğini bildirir.
+    public static final byte RESP_ACCEPT = 'A';
+
+    // 'R' yanıtı, join isteğinin REDDEDİLDİĞİNİ/yeniden yönlendirilmesi gerektiğini belirtir.
+    public static final byte RESP_REJECT = 'R';
+
+    // 1 baytlık chunk işaretleyicisi, STREAM yanıtında yeni bir kaydın geldiğini gösterir.
+    public static final byte STREAM_CHUNK_MARKER = 1;
+
+    // 0 baytlık işaretleyici, STREAM yanıtında aktarımın sona erdiğini gösterir.
+    public static final byte STREAM_END_MARKER = 0;
 }

--- a/src/main/java/com/can/core/CacheEngine.java
+++ b/src/main/java/com/can/core/CacheEngine.java
@@ -1,6 +1,7 @@
 package com.can.core;
 
 import com.can.codec.Codec;
+import com.can.constants.NodeProtocol;
 import com.can.core.model.CacheValue;
 import com.can.core.model.CasDecision;
 import com.can.core.model.CasResult;
@@ -280,9 +281,9 @@ public final class CacheEngine<K,V> implements AutoCloseable
     // Replay entry from persistence layer
     public void replay(byte[] op, byte[] k, byte[] v, long expireAt){
         K key = keyCodec.decode(k);
-        if (op[0] == 'S') {
+        if (op[0] == NodeProtocol.CMD_SET) {
             applyReplayEntry(key, v, expireAt);
-        } else if (op[0] == 'D') {
+        } else if (op[0] == NodeProtocol.CMD_DELETE) {
             applyReplayDelete(key);
         }
     }

--- a/src/main/java/com/can/rdb/SnapshotFile.java
+++ b/src/main/java/com/can/rdb/SnapshotFile.java
@@ -1,6 +1,7 @@
 package com.can.rdb;
 
 import com.can.codec.Codec;
+import com.can.constants.NodeProtocol;
 import com.can.core.CacheEngine;
 
 import java.io.BufferedReader;
@@ -31,7 +32,7 @@ public record SnapshotFile<K, V>(File file, Codec<K> keyCodec) {
                 try {
                     engine.forEachEntry((key, value, expireAt) -> {
                         try {
-                            writer.write('S');
+                            writer.write(NodeProtocol.CMD_SET);
                             writer.write(' ');
                             writer.write(Base64.getEncoder().encodeToString(keyCodec.encode(key)));
                             writer.write(' ');

--- a/src/test/java/com/can/core/CacheEngineTest.java
+++ b/src/test/java/com/can/core/CacheEngineTest.java
@@ -1,6 +1,7 @@
 package com.can.core;
 
 import com.can.codec.StringCodec;
+import com.can.constants.NodeProtocol;
 import com.can.metric.MetricsRegistry;
 import com.can.metric.Timer;
 import com.can.pubsub.Broker;
@@ -155,7 +156,7 @@ class CacheEngineTest
         @Test
         void replay_set_command_restores_value()
         {
-            engine.replay(new byte[]{'S'}, StringCodec.UTF8.encode("key"), StringCodec.UTF8.encode("value"), 0L);
+            engine.replay(new byte[]{NodeProtocol.CMD_SET}, StringCodec.UTF8.encode("key"), StringCodec.UTF8.encode("value"), 0L);
             assertEquals("value", engine.get("key"));
         }
 
@@ -163,7 +164,7 @@ class CacheEngineTest
         @Test
         void replay_ignores_expired_record()
         {
-            engine.replay(new byte[]{'S'}, StringCodec.UTF8.encode("late"), StringCodec.UTF8.encode("value"), System.currentTimeMillis() - 1_000);
+            engine.replay(new byte[]{NodeProtocol.CMD_SET}, StringCodec.UTF8.encode("late"), StringCodec.UTF8.encode("value"), System.currentTimeMillis() - 1_000);
             assertNull(engine.get("late"));
         }
 
@@ -172,7 +173,7 @@ class CacheEngineTest
         void replay_delete_command_removes_entry()
         {
             assertTrue(engine.set("gone", "value"));
-            engine.replay(new byte[]{'D'}, StringCodec.UTF8.encode("gone"), new byte[0], 0L);
+            engine.replay(new byte[]{NodeProtocol.CMD_DELETE}, StringCodec.UTF8.encode("gone"), new byte[0], 0L);
             assertNull(engine.get("gone"));
         }
     }


### PR DESCRIPTION
## Summary
- extend `NodeProtocol` with join, stream, digest, handshake, and stream marker constants
- replace hard-coded protocol bytes across replication, coordination, cache replay, and snapshot code with the shared constants
- update cache engine replay tests to build protocol operations from the constants

## Testing
- `./mvnw -q -DskipITs test` *(fails: wget cannot reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cbd1974083238cecf344a76d0ecf