### PR TITLE
Replace deprecated executeBlocking handlers

### DIFF
--- a/src/main/java/com/can/cluster/coordination/ReplicationServer.java
+++ b/src/main/java/com/can/cluster/coordination/ReplicationServer.java
@@ -182,14 +182,7 @@ public class ReplicationServer implements AutoCloseable
         private void executeCommand(CommandAction action)
         {
             processing = true;
-            workerExecutor.<Buffer>executeBlocking(promise -> {
-                try {
-                    Buffer response = action.execute();
-                    promise.complete(response);
-                } catch (Throwable t) {
-                    promise.fail(t);
-                }
-            }, false, ar -> {
+            workerExecutor.<Buffer>executeBlocking(() -> action.execute(), false).onComplete(ar -> {
                 processing = false;
                 if (closed) {
                     return;

--- a/src/main/java/com/can/core/CacheEngine.java
+++ b/src/main/java/com/can/core/CacheEngine.java
@@ -101,9 +101,9 @@ public final class CacheEngine<K,V> implements AutoCloseable
 
     private void startCleaner() {
         cleanerTimerId = vertx.setPeriodic(cleanerPollMillis, id ->
-                vertx.executeBlocking(promise -> {
+                vertx.executeBlocking(() -> {
                     runCleaner();
-                    promise.complete();
+                    return null;
                 })
         );
     }

--- a/src/main/java/com/can/metric/MetricsReporter.java
+++ b/src/main/java/com/can/metric/MetricsReporter.java
@@ -51,9 +51,9 @@ public class MetricsReporter implements AutoCloseable
         }
         long periodMillis = TimeUnit.SECONDS.toMillis(intervalSeconds);
         timerId = vertx.setPeriodic(periodMillis, id ->
-                workerExecutor.executeBlocking(promise -> {
+                workerExecutor.executeBlocking(() -> {
                     dump();
-                    promise.complete();
+                    return null;
                 })
         );
     }

--- a/src/main/java/com/can/net/CanCachedServer.java
+++ b/src/main/java/com/can/net/CanCachedServer.java
@@ -850,13 +850,7 @@ public class CanCachedServer implements AutoCloseable
         private void executeCommand(Supplier<CommandResult> executor)
         {
             processing = true;
-            vertx.<CommandResult>executeBlocking(promise -> {
-                try {
-                    promise.complete(executor.get());
-                } catch (Throwable t) {
-                    promise.fail(t);
-                }
-            }, false, ar -> {
+            vertx.<CommandResult>executeBlocking(() -> executor.get(), false).onComplete(ar -> {
                 processing = false;
                 if (closed) {
                     return;

--- a/src/main/java/com/can/rdb/SnapshotScheduler.java
+++ b/src/main/java/com/can/rdb/SnapshotScheduler.java
@@ -67,16 +67,16 @@ public class SnapshotScheduler implements AutoCloseable
             return;
         }
         started.set(true);
-        workerExecutor.executeBlocking(promise -> {
+        workerExecutor.executeBlocking(() -> {
             safeSnapshot();
-            promise.complete();
+            return null;
         });
         if (intervalSeconds > 0) {
             long delay = TimeUnit.SECONDS.toMillis(intervalSeconds);
             periodicTimerId = vertx.setPeriodic(delay, id ->
-                    workerExecutor.executeBlocking(promise -> {
+                    workerExecutor.executeBlocking(() -> {
                         safeSnapshot();
-                        promise.complete();
+                        return null;
                     })
             );
         }


### PR DESCRIPTION
## Summary
- replace all handler-based executeBlocking usages with the Callable-returning overloads to avoid deprecated APIs

## Testing
- ./mvnw -q -DskipTests package *(fails: wget could not download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e4362e7883239e98ecc863a92f48