### PR TITLE
Create performance-tests aggregator module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY mvnw ./
 COPY .mvn .mvn
 COPY application/pom.xml application/pom.xml
 COPY integration-tests/pom.xml integration-tests/pom.xml
+COPY performance-tests/pom.xml performance-tests/pom.xml
 COPY performance-tests/java-sampler/pom.xml performance-tests/java-sampler/pom.xml
 RUN chmod +x mvnw
 RUN ./mvnw -B -pl application -am dependency:go-offline

--- a/performance-tests/java-sampler/pom.xml
+++ b/performance-tests/java-sampler/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.can</groupId>
-        <artifactId>can-cache-parent</artifactId>
+        <artifactId>performance-tests</artifactId>
         <version>0.0.1-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>can-cache-jmeter-sampler</artifactId>

--- a/performance-tests/pom.xml
+++ b/performance-tests/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.can</groupId>
+        <artifactId>can-cache-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>performance-tests</artifactId>
+    <packaging>pom</packaging>
+    <name>Can Cache Performance Tests</name>
+    <description>Aggregator module for Can Cache performance testing artefacts.</description>
+
+    <modules>
+        <module>java-sampler</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,6 @@
     <modules>
         <module>application</module>
         <module>integration-tests</module>
-        <module>performance-tests/java-sampler</module>
+        <module>performance-tests</module>
     </modules>
 </project>


### PR DESCRIPTION
## Summary
- add a parent POM under performance-tests to aggregate performance testing artefacts
- reparent the Java sampler module and update the top-level build and Dockerfile to reference the new aggregator

## Testing
- ./mvnw -pl application -am package -DskipTests

------
https://chatgpt.com/codex/tasks/task_e_68d8567cde1483238e1b16a3dc0adea5