### PR TITLE
Fix integration tests Docker build failure

### DIFF
--- a/can-cache-integration-tests/pom.xml
+++ b/can-cache-integration-tests/pom.xml
@@ -4,14 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>com.can</groupId>
-        <artifactId>can-cache-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
-
+    <groupId>com.can</groupId>
     <artifactId>can-cache-integration-tests</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary
- make the integration tests module declare its own Maven coordinates so it no longer depends on the parent POM during image builds

## Testing
- mvn -pl can-cache-integration-tests dependency:go-offline

------
https://chatgpt.com/codex/tasks/task_e_68d860f2fb3083238960de0d22fa5bbf