### PR TITLE
Fix Docker image to run Quarkus fast jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN ls -la can-cache-application/target && (ls -la can-cache-application/target/
 
 FROM eclipse-temurin:24-jre
 WORKDIR /opt/can-cache
-COPY --from=build /workspace/app/can-cache-application/target/*-runner.jar ./app.jar
+COPY --from=build /workspace/app/can-cache-application/target/quarkus-app ./quarkus-app
 EXPOSE 11211
-ENTRYPOINT ["java","-jar","/opt/can-cache/app.jar"]
+ENTRYPOINT ["java","-jar","/opt/can-cache/quarkus-app/quarkus-run.jar"]

--- a/can-cache-application/pom.xml
+++ b/can-cache-application/pom.xml
@@ -75,6 +75,15 @@
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- ensure the Quarkus Maven plugin executes its build and code generation goals so the fast-jar layout is produced
- update the runtime image to copy the generated quarkus-app directory and run the quarkus-run.jar entry point

## Testing
- ./mvnw -pl can-cache-application -am package -DskipTests

------
https://chatgpt.com/codex/tasks/task_e_68d864f0563c8323b8153636ee84aa26