### PR TITLE
Add dynamic port allocation for server components

### DIFF
--- a/can-cache-application/src/main/java/com/can/cluster/coordination/CoordinationService.java
+++ b/can-cache-application/src/main/java/com/can/cluster/coordination/CoordinationService.java
@@ -2,6 +2,7 @@ package com.can.cluster.coordination;
 
 import com.can.cluster.*;
 import com.can.config.AppProperties;
+import com.can.config.PortAllocator;
 import com.can.constants.NodeProtocol;
 import com.can.core.CacheEngine;
 import io.vertx.core.Vertx;
@@ -64,6 +65,7 @@ public class CoordinationService implements AutoCloseable
     private final long antiEntropyIntervalMillis;
     private final Vertx vertx;
     private final ExecutorService taskExecutor;
+    private final int localReplicationPort;
 
     private final Map<String, RemoteMember> members = new ConcurrentHashMap<>();
     private final Object membershipLock = new Object();
@@ -84,7 +86,8 @@ public class CoordinationService implements AutoCloseable
                                HintedHandoffService hintedHandoffService,
                                CacheEngine<String, String> localEngine,
                                AppProperties properties,
-                               Vertx vertx) {
+                               Vertx vertx,
+                               PortAllocator portAllocator) {
         this.ring = ring;
         this.localNode = localNode;
         this.clusterState = clusterState;
@@ -100,6 +103,7 @@ public class CoordinationService implements AutoCloseable
         this.vertx = vertx;
         ThreadFactory threadFactory = Thread.ofVirtual().name("coordination-task-", 0).factory();
         this.taskExecutor = Executors.newThreadPerTaskExecutor(threadFactory);
+        this.localReplicationPort = Objects.requireNonNull(portAllocator, "portAllocator").replicationPort();
     }
 
     @PostConstruct
@@ -128,7 +132,7 @@ public class CoordinationService implements AutoCloseable
         repairTimerId = vertx.setPeriodic(repairInterval, id -> submitAntiEntropyTask());
 
         LOG.infof("Coordination service started for node %s, announcing %s:%d", localNode.id(),
-                advertisedHost(), replicationConfig.port());
+                advertisedHost(), localReplicationPort);
     }
 
     private void setupSockets() throws IOException
@@ -504,7 +508,7 @@ public class CoordinationService implements AutoCloseable
 
     private void broadcastHeartbeat()
     {
-        String payload = String.format("HELLO|%s|%s|%d|%d", localNode.id(), advertisedHost(), replicationConfig.port(),
+        String payload = String.format("HELLO|%s|%s|%d|%d", localNode.id(), advertisedHost(), localReplicationPort,
                 clusterState.currentEpoch());
         byte[] bytes = payload.getBytes(StandardCharsets.UTF_8);
         DatagramPacket packet = new DatagramPacket(bytes, bytes.length, groupAddress, discoveryConfig.multicastPort());

--- a/can-cache-application/src/main/java/com/can/cluster/coordination/ReplicationServer.java
+++ b/can-cache-application/src/main/java/com/can/cluster/coordination/ReplicationServer.java
@@ -2,6 +2,7 @@ package com.can.cluster.coordination;
 
 import com.can.cluster.ClusterState;
 import com.can.config.AppProperties;
+import com.can.config.PortAllocator;
 import com.can.constants.NodeProtocol;
 import com.can.core.CacheEngine;
 import io.quarkus.runtime.Startup;
@@ -43,6 +44,7 @@ public class ReplicationServer implements AutoCloseable
     private final ClusterState clusterState;
     private final WorkerExecutor workerExecutor;
     private final Vertx vertx;
+    private final int listenPort;
 
     private volatile boolean running;
     private NetServer netServer;
@@ -53,13 +55,15 @@ public class ReplicationServer implements AutoCloseable
                              ClusterState clusterState,
                              AppProperties properties,
                              WorkerExecutor workerExecutor,
-                             Vertx vertx)
+                             Vertx vertx,
+                             PortAllocator portAllocator)
     {
         this.engine = engine;
         this.clusterState = clusterState;
         this.config = properties.cluster().replication();
         this.workerExecutor = workerExecutor;
         this.vertx = vertx;
+        this.listenPort = Objects.requireNonNull(portAllocator, "portAllocator").replicationPort();
     }
 
     @PostConstruct
@@ -67,7 +71,7 @@ public class ReplicationServer implements AutoCloseable
     {
         NetServerOptions options = new NetServerOptions()
                 .setHost(config.bindHost())
-                .setPort(config.port())
+                .setPort(listenPort)
                 .setTcpNoDelay(true)
                 .setReuseAddress(true);
 
@@ -81,7 +85,7 @@ public class ReplicationServer implements AutoCloseable
 
         running = true;
         LOG.infof("Replication server listening on %s:%d (advertised as %s:%d)",
-                config.bindHost(), netServer.actualPort(), config.advertiseHost(), config.port());
+                config.bindHost(), netServer.actualPort(), config.advertiseHost(), listenPort);
     }
 
     private void onClientConnected(NetSocket socket)

--- a/can-cache-application/src/main/java/com/can/config/AppConfig.java
+++ b/can-cache-application/src/main/java/com/can/config/AppConfig.java
@@ -24,6 +24,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Objects;
 
 import java.io.File;
 import java.time.Duration;
@@ -170,8 +171,9 @@ public class AppConfig {
 
     @Produces
     @Singleton
-    public Node<String, String> localNode(CacheEngine<String, String> engine)
+    public Node<String, String> localNode(CacheEngine<String, String> engine, PortAllocator portAllocator)
     {
+        Objects.requireNonNull(portAllocator, "portAllocator");
         var discovery = properties.cluster().discovery();
         var replication = properties.cluster().replication();
         String nodeId = discovery.nodeId()
@@ -184,7 +186,7 @@ public class AppConfig {
                     if (host == null || host.isBlank() || "0.0.0.0".equals(host)) {
                         host = "127.0.0.1";
                     }
-                    return host + ":" + replication.port();
+                    return host + ":" + portAllocator.replicationPort();
                 });
         final String resolvedId = nodeId;
         return new Node<>() {

--- a/can-cache-application/src/main/java/com/can/config/PortAllocator.java
+++ b/can-cache-application/src/main/java/com/can/config/PortAllocator.java
@@ -1,0 +1,110 @@
+package com.can.config;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+
+/**
+ * Provides runtime resolution for network ports that may already be occupied
+ * when multiple application instances are started on the same host. The
+ * allocator checks whether the requested port from configuration is available
+ * and falls back to an automatically assigned free port when necessary.
+ */
+@Singleton
+public class PortAllocator
+{
+    private static final Logger LOG = Logger.getLogger(PortAllocator.class);
+
+    private final int networkPort;
+    private final int replicationPort;
+    private final int metricsPort;
+
+    @Inject
+    public PortAllocator(AppProperties properties)
+    {
+        var network = properties.network();
+        this.networkPort = resolveTcpPort(network.host(), network.port(), "cancached server");
+
+        var replication = properties.cluster().replication();
+        this.replicationPort = resolveTcpPort(replication.bindHost(), replication.port(), "replication server");
+
+        var metrics = properties.metrics();
+        if (metrics.endpointEnabled()) {
+            this.metricsPort = resolveTcpPort(metrics.endpointHost(), metrics.endpointPort(), "metrics endpoint");
+        }
+        else {
+            this.metricsPort = metrics.endpointPort();
+        }
+    }
+
+    public int networkPort()
+    {
+        return networkPort;
+    }
+
+    public int replicationPort()
+    {
+        return replicationPort;
+    }
+
+    public int metricsPort()
+    {
+        return metricsPort;
+    }
+
+    private int resolveTcpPort(String host, int requestedPort, String componentName)
+    {
+        if (requestedPort <= 0) {
+            return findFreeTcpPort(host);
+        }
+        if (isPortAvailable(host, requestedPort)) {
+            return requestedPort;
+        }
+        int fallback = findFreeTcpPort(host);
+        LOG.warnf("Port %d for %s on host %s is already in use, falling back to %d", requestedPort, componentName,
+                hostOrWildcard(host), fallback);
+        return fallback;
+    }
+
+    private boolean isPortAvailable(String host, int port)
+    {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(true);
+            socket.bind(socketAddress(host, port));
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private int findFreeTcpPort(String host)
+    {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(true);
+            socket.bind(socketAddress(host, 0));
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to allocate free TCP port", e);
+        }
+    }
+
+    private InetSocketAddress socketAddress(String host, int port)
+    {
+        if (host == null || host.isBlank()) {
+            return new InetSocketAddress(port);
+        }
+        return new InetSocketAddress(host, port);
+    }
+
+    private String hostOrWildcard(String host)
+    {
+        if (host == null || host.isBlank()) {
+            return "0.0.0.0";
+        }
+        return host;
+    }
+}

--- a/can-cache-application/src/main/java/com/can/metric/MetricsReporter.java
+++ b/can-cache-application/src/main/java/com/can/metric/MetricsReporter.java
@@ -2,6 +2,7 @@ package com.can.metric;
 
 import com.can.cluster.ClusterState;
 import com.can.config.AppProperties;
+import com.can.config.PortAllocator;
 import io.quarkus.runtime.Startup;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
@@ -15,6 +16,7 @@ import org.jboss.logging.Logger;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -49,17 +51,20 @@ public class MetricsReporter implements AutoCloseable
     public MetricsReporter(MetricsRegistry registry,
                            AppProperties properties,
                            ClusterState clusterState,
-                           Vertx vertx)
+                           Vertx vertx,
+                           PortAllocator portAllocator)
     {
         this(registry,
                 properties.metrics(),
                 clusterState != null ? clusterState::localNodeId : () -> "unknown",
+                resolveMetricsPort(portAllocator),
                 vertx);
     }
 
     MetricsReporter(MetricsRegistry registry,
                     AppProperties.Metrics metricsConfig,
                     Supplier<String> nodeIdSupplier,
+                    int resolvedPort,
                     Vertx vertx)
     {
         this.registry = registry;
@@ -67,9 +72,14 @@ public class MetricsReporter implements AutoCloseable
         this.replicationRole = sanitizeLabelValue(metricsConfig.replicationRole());
         this.metricsPath = normalisePath(metricsConfig.endpointPath());
         this.listenHost = metricsConfig.endpointHost();
-        this.listenPort = metricsConfig.endpointPort();
+        this.listenPort = resolvedPort;
         this.enabled = metricsConfig.endpointEnabled();
         this.vertx = vertx;
+    }
+
+    private static int resolveMetricsPort(PortAllocator portAllocator)
+    {
+        return Objects.requireNonNull(portAllocator, "portAllocator").metricsPort();
     }
 
     @PostConstruct

--- a/can-cache-application/src/main/java/com/can/net/CanCachedServer.java
+++ b/can-cache-application/src/main/java/com/can/net/CanCachedServer.java
@@ -2,6 +2,7 @@ package com.can.net;
 
 import com.can.cluster.ClusterClient;
 import com.can.config.AppProperties;
+import com.can.config.PortAllocator;
 import com.can.constants.CanCachedProtocol;
 import com.can.core.CacheEngine;
 import com.can.core.StoredValueCodec;
@@ -50,6 +51,7 @@ public class CanCachedServer implements AutoCloseable
     private final int maxItemSize;
     private final int maxCasRetries;
     private final CacheEngine<String, String> localEngine;
+    private final int listenPort;
 
     private final AtomicLong casCounter = new AtomicLong(1L);
     private final AtomicLong cmdGet = new AtomicLong();
@@ -73,7 +75,8 @@ public class CanCachedServer implements AutoCloseable
     public CanCachedServer(Vertx vertx,
                            ClusterClient clusterClient,
                            AppProperties properties,
-                           CacheEngine<String, String> localEngine)
+                           CacheEngine<String, String> localEngine,
+                           PortAllocator portAllocator)
     {
         this.vertx = Objects.requireNonNull(vertx, "vertx");
         this.clusterClient = Objects.requireNonNull(clusterClient, "clusterClient");
@@ -82,6 +85,7 @@ public class CanCachedServer implements AutoCloseable
         this.maxItemSize = Math.max(1, cancacheConfig.maxItemSizeBytes());
         this.maxCasRetries = Math.max(1, cancacheConfig.maxCasRetries());
         this.localEngine = Objects.requireNonNull(localEngine, "localEngine");
+        this.listenPort = Objects.requireNonNull(portAllocator, "portAllocator").networkPort();
     }
 
     @PostConstruct
@@ -89,7 +93,7 @@ public class CanCachedServer implements AutoCloseable
     {
         NetServerOptions options = new NetServerOptions()
                 .setHost(networkConfig.host())
-                .setPort(networkConfig.port())
+                .setPort(listenPort)
                 .setTcpNoDelay(true)
                 .setReuseAddress(true)
                 .setAcceptBacklog(Math.max(1, networkConfig.backlog()));
@@ -758,7 +762,7 @@ public class CanCachedServer implements AutoCloseable
 
     public int port()
     {
-        return netServer != null ? netServer.actualPort() : networkConfig.port();
+        return netServer != null ? netServer.actualPort() : listenPort;
     }
 
     @PreDestroy

--- a/can-cache-application/src/test/java/com/can/metric/MetricsComponentsTest.java
+++ b/can-cache-application/src/test/java/com/can/metric/MetricsComponentsTest.java
@@ -83,7 +83,7 @@ class MetricsComponentsTest
 
             Vertx vertx = Vertx.vertx();
             FakeMetricsConfig config = new FakeMetricsConfig();
-            MetricsReporter reporter = new MetricsReporter(registry, config, () -> "node-1", vertx);
+            MetricsReporter reporter = new MetricsReporter(registry, config, () -> "node-1", config.endpointPort(), vertx);
 
             try
             {
@@ -121,7 +121,7 @@ class MetricsComponentsTest
             Vertx vertx = Vertx.vertx();
             FakeMetricsConfig config = new FakeMetricsConfig();
             config.enabled = false;
-            MetricsReporter reporter = new MetricsReporter(registry, config, () -> "node-1", vertx);
+            MetricsReporter reporter = new MetricsReporter(registry, config, () -> "node-1", config.endpointPort(), vertx);
             try
             {
                 reporter.start();


### PR DESCRIPTION
## Summary
- introduce a dedicated PortAllocator bean that resolves free TCP ports when the configured ones are in use
- update the TCP servers and coordination logic to rely on the resolved ports for binding and cluster announcements
- adjust metrics reporter construction and tests to work with dynamically chosen ports

## Testing
- ./mvnw -pl can-cache-application test *(fails: container JDK lacks support for release 24)*

------
https://chatgpt.com/codex/tasks/task_e_68d9995402c8832397afd587c54c5492