### PR TITLE
Implement sequential host/port fallback for duplicate instances

### DIFF
--- a/can-cache-application/src/main/java/com/can/cluster/coordination/CoordinationService.java
+++ b/can-cache-application/src/main/java/com/can/cluster/coordination/CoordinationService.java
@@ -2,6 +2,7 @@ package com.can.cluster.coordination;
 
 import com.can.cluster.*;
 import com.can.config.AppProperties;
+import com.can.config.PortAllocator;
 import com.can.constants.NodeProtocol;
 import com.can.core.CacheEngine;
 import io.vertx.core.Vertx;
@@ -64,6 +65,9 @@ public class CoordinationService implements AutoCloseable
     private final long antiEntropyIntervalMillis;
     private final Vertx vertx;
     private final ExecutorService taskExecutor;
+    private final int localReplicationPort;
+    private final String replicationBindHost;
+    private final String replicationAdvertisedHost;
 
     private final Map<String, RemoteMember> members = new ConcurrentHashMap<>();
     private final Object membershipLock = new Object();
@@ -84,7 +88,8 @@ public class CoordinationService implements AutoCloseable
                                HintedHandoffService hintedHandoffService,
                                CacheEngine<String, String> localEngine,
                                AppProperties properties,
-                               Vertx vertx) {
+                               Vertx vertx,
+                               PortAllocator portAllocator) {
         this.ring = ring;
         this.localNode = localNode;
         this.clusterState = clusterState;
@@ -100,6 +105,10 @@ public class CoordinationService implements AutoCloseable
         this.vertx = vertx;
         ThreadFactory threadFactory = Thread.ofVirtual().name("coordination-task-", 0).factory();
         this.taskExecutor = Executors.newThreadPerTaskExecutor(threadFactory);
+        Objects.requireNonNull(portAllocator, "portAllocator");
+        this.replicationBindHost = portAllocator.replicationHost();
+        this.replicationAdvertisedHost = portAllocator.replicationAdvertiseHost();
+        this.localReplicationPort = portAllocator.replicationPort();
     }
 
     @PostConstruct
@@ -128,7 +137,7 @@ public class CoordinationService implements AutoCloseable
         repairTimerId = vertx.setPeriodic(repairInterval, id -> submitAntiEntropyTask());
 
         LOG.infof("Coordination service started for node %s, announcing %s:%d", localNode.id(),
-                advertisedHost(), replicationConfig.port());
+                advertisedHost(), localReplicationPort);
     }
 
     private void setupSockets() throws IOException
@@ -146,7 +155,8 @@ public class CoordinationService implements AutoCloseable
     {
         // Önce bind host'u deneyelim, değilse multicast destekleyen ilk arayüzü seçelim.
         try {
-            InetAddress bindAddress = InetAddress.getByName(replicationConfig.bindHost());
+            InetAddress bindAddress = InetAddress.getByName(replicationBindHost != null ? replicationBindHost
+                    : replicationConfig.bindHost());
             NetworkInterface ni = NetworkInterface.getByInetAddress(bindAddress);
             if (ni != null && ni.isUp() && ni.supportsMulticast()) {
                 return ni;
@@ -504,7 +514,7 @@ public class CoordinationService implements AutoCloseable
 
     private void broadcastHeartbeat()
     {
-        String payload = String.format("HELLO|%s|%s|%d|%d", localNode.id(), advertisedHost(), replicationConfig.port(),
+        String payload = String.format("HELLO|%s|%s|%d|%d", localNode.id(), advertisedHost(), localReplicationPort,
                 clusterState.currentEpoch());
         byte[] bytes = payload.getBytes(StandardCharsets.UTF_8);
         DatagramPacket packet = new DatagramPacket(bytes, bytes.length, groupAddress, discoveryConfig.multicastPort());
@@ -549,6 +559,9 @@ public class CoordinationService implements AutoCloseable
     }
 
     private String advertisedHost() {
+        if (replicationAdvertisedHost != null && !replicationAdvertisedHost.isBlank()) {
+            return replicationAdvertisedHost;
+        }
         String host = replicationConfig.advertiseHost();
         if (host == null || host.isBlank() || Objects.equals(host, "0.0.0.0")) {
             return InetAddress.getLoopbackAddress().getHostAddress();

--- a/can-cache-application/src/main/java/com/can/cluster/coordination/ReplicationServer.java
+++ b/can-cache-application/src/main/java/com/can/cluster/coordination/ReplicationServer.java
@@ -2,6 +2,7 @@ package com.can.cluster.coordination;
 
 import com.can.cluster.ClusterState;
 import com.can.config.AppProperties;
+import com.can.config.PortAllocator;
 import com.can.constants.NodeProtocol;
 import com.can.core.CacheEngine;
 import io.quarkus.runtime.Startup;
@@ -43,6 +44,9 @@ public class ReplicationServer implements AutoCloseable
     private final ClusterState clusterState;
     private final WorkerExecutor workerExecutor;
     private final Vertx vertx;
+    private final String bindHost;
+    private final String advertisedHost;
+    private final int listenPort;
 
     private volatile boolean running;
     private NetServer netServer;
@@ -53,21 +57,26 @@ public class ReplicationServer implements AutoCloseable
                              ClusterState clusterState,
                              AppProperties properties,
                              WorkerExecutor workerExecutor,
-                             Vertx vertx)
+                             Vertx vertx,
+                             PortAllocator portAllocator)
     {
         this.engine = engine;
         this.clusterState = clusterState;
         this.config = properties.cluster().replication();
         this.workerExecutor = workerExecutor;
         this.vertx = vertx;
+        Objects.requireNonNull(portAllocator, "portAllocator");
+        this.bindHost = portAllocator.replicationHost();
+        this.advertisedHost = portAllocator.replicationAdvertiseHost();
+        this.listenPort = portAllocator.replicationPort();
     }
 
     @PostConstruct
     void start()
     {
         NetServerOptions options = new NetServerOptions()
-                .setHost(config.bindHost())
-                .setPort(config.port())
+                .setHost(bindHost != null ? bindHost : config.bindHost())
+                .setPort(listenPort)
                 .setTcpNoDelay(true)
                 .setReuseAddress(true);
 
@@ -80,8 +89,10 @@ public class ReplicationServer implements AutoCloseable
         }
 
         running = true;
+        String effectiveBindHost = bindHost != null ? bindHost : config.bindHost();
+        String effectiveAdvertiseHost = advertisedHost != null ? advertisedHost : config.advertiseHost();
         LOG.infof("Replication server listening on %s:%d (advertised as %s:%d)",
-                config.bindHost(), netServer.actualPort(), config.advertiseHost(), config.port());
+                effectiveBindHost, netServer.actualPort(), effectiveAdvertiseHost, listenPort);
     }
 
     private void onClientConnected(NetSocket socket)

--- a/can-cache-application/src/main/java/com/can/config/AppConfig.java
+++ b/can-cache-application/src/main/java/com/can/config/AppConfig.java
@@ -24,6 +24,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Objects;
 
 import java.io.File;
 import java.time.Duration;
@@ -170,21 +171,21 @@ public class AppConfig {
 
     @Produces
     @Singleton
-    public Node<String, String> localNode(CacheEngine<String, String> engine)
+    public Node<String, String> localNode(CacheEngine<String, String> engine, PortAllocator portAllocator)
     {
+        Objects.requireNonNull(portAllocator, "portAllocator");
         var discovery = properties.cluster().discovery();
-        var replication = properties.cluster().replication();
         String nodeId = discovery.nodeId()
                 .filter(id -> !id.isBlank())
                 .orElseGet(() -> {
-                    String host = replication.advertiseHost();
+                    String host = portAllocator.replicationAdvertiseHost();
                     if (host == null || host.isBlank() || "0.0.0.0".equals(host)) {
-                        host = replication.bindHost();
+                        host = portAllocator.replicationHost();
                     }
                     if (host == null || host.isBlank() || "0.0.0.0".equals(host)) {
                         host = "127.0.0.1";
                     }
-                    return host + ":" + replication.port();
+                    return host + ":" + portAllocator.replicationPort();
                 });
         final String resolvedId = nodeId;
         return new Node<>() {

--- a/can-cache-application/src/main/java/com/can/config/PortAllocator.java
+++ b/can-cache-application/src/main/java/com/can/config/PortAllocator.java
@@ -1,0 +1,268 @@
+package com.can.config;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Provides runtime resolution for network ports that may already be occupied
+ * when multiple application instances are started on the same host. The
+ * allocator checks whether the requested port from configuration is available
+ * and falls back to an automatically assigned free port when necessary.
+ */
+@Singleton
+public class PortAllocator
+{
+    private static final Logger LOG = Logger.getLogger(PortAllocator.class);
+    private static final int MAX_PORT = 65_535;
+    private static final Pattern TRAILING_NUMBER = Pattern.compile("(.*?)(\\d+)$");
+
+    private final ResolvedEndpoint networkEndpoint;
+    private final ResolvedEndpoint replicationEndpoint;
+    private final ResolvedEndpoint metricsEndpoint;
+    private final String replicationAdvertiseHost;
+
+    @Inject
+    public PortAllocator(AppProperties properties)
+    {
+        var network = properties.network();
+        this.networkEndpoint = resolveEndpoint(network.host(), network.port(), "cancached server",
+                allowHostIncrement(network.host()));
+
+        var replication = properties.cluster().replication();
+        this.replicationEndpoint = resolveEndpoint(replication.bindHost(), replication.port(), "replication server",
+                allowHostIncrement(replication.bindHost()));
+        this.replicationAdvertiseHost = resolveAdvertiseHost(replication.advertiseHost(), replication.bindHost(),
+                replicationEndpoint.host());
+
+        var metrics = properties.metrics();
+        if (metrics.endpointEnabled()) {
+            this.metricsEndpoint = resolveEndpoint(metrics.endpointHost(), metrics.endpointPort(), "metrics endpoint",
+                    allowHostIncrement(metrics.endpointHost()));
+        }
+        else {
+            this.metricsEndpoint = new ResolvedEndpoint(metrics.endpointHost(), metrics.endpointPort());
+        }
+    }
+
+    public String networkHost()
+    {
+        return networkEndpoint.host();
+    }
+
+    public int networkPort()
+    {
+        return networkEndpoint.port();
+    }
+
+    public String replicationHost()
+    {
+        return replicationEndpoint.host();
+    }
+
+    public int replicationPort()
+    {
+        return replicationEndpoint.port();
+    }
+
+    public String replicationAdvertiseHost()
+    {
+        return replicationAdvertiseHost;
+    }
+
+    public String metricsHost()
+    {
+        return metricsEndpoint.host();
+    }
+
+    public int metricsPort()
+    {
+        return metricsEndpoint.port();
+    }
+
+    private ResolvedEndpoint resolveEndpoint(String host, int requestedPort, String componentName, boolean incrementHost)
+    {
+        if (requestedPort <= 0) {
+            return new ResolvedEndpoint(host, findFreeTcpPort(host));
+        }
+        String candidateHost = host;
+        int candidatePort = requestedPort;
+        boolean loggedConflict = false;
+        while (candidatePort > 0 && candidatePort <= MAX_PORT) {
+            if (isPortAvailable(candidateHost, candidatePort)) {
+                if (loggedConflict || candidatePort != requestedPort || !Objects.equals(candidateHost, host)) {
+                    LOG.warnf("Port %d for %s on host %s is already in use, falling back to %s:%d",
+                            requestedPort, componentName, hostOrWildcard(host), hostOrWildcard(candidateHost),
+                            candidatePort);
+                }
+                return new ResolvedEndpoint(candidateHost, candidatePort);
+            }
+            if (!loggedConflict) {
+                LOG.warnf("Port %d for %s on host %s is already in use, trying next host/port combination",
+                        requestedPort, componentName, hostOrWildcard(host));
+                loggedConflict = true;
+            }
+            if (candidatePort == MAX_PORT) {
+                break;
+            }
+            ResolvedEndpoint next = nextEndpoint(candidateHost, candidatePort, incrementHost);
+            if (next.port() == candidatePort && Objects.equals(next.host(), candidateHost)) {
+                break;
+            }
+            candidateHost = next.host();
+            candidatePort = next.port();
+        }
+        throw new IllegalStateException("No available port for " + componentName + " after checking from "
+                + requestedPort + " to " + MAX_PORT);
+    }
+
+    private ResolvedEndpoint nextEndpoint(String host, int port, boolean incrementHost)
+    {
+        int nextPort = Math.min(MAX_PORT, port + 1);
+        String nextHost = host;
+        if (incrementHost) {
+            String updatedHost = incrementHostValue(host);
+            if (!Objects.equals(updatedHost, host)) {
+                nextHost = updatedHost;
+            }
+        }
+        return new ResolvedEndpoint(nextHost, nextPort);
+    }
+
+    private boolean isPortAvailable(String host, int port)
+    {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(true);
+            socket.bind(socketAddress(host, port));
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private int findFreeTcpPort(String host)
+    {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(true);
+            socket.bind(socketAddress(host, 0));
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to allocate free TCP port", e);
+        }
+    }
+
+    private String resolveAdvertiseHost(String configuredAdvertiseHost, String originalBindHost, String resolvedBindHost)
+    {
+        if (isWildcardHost(configuredAdvertiseHost)) {
+            if (isWildcardHost(resolvedBindHost)) {
+                return InetAddress.getLoopbackAddress().getHostAddress();
+            }
+            return resolvedBindHost;
+        }
+        if (Objects.equals(configuredAdvertiseHost, originalBindHost)) {
+            return resolvedBindHost;
+        }
+        return configuredAdvertiseHost;
+    }
+
+    private InetSocketAddress socketAddress(String host, int port)
+    {
+        if (host == null || host.isBlank()) {
+            return new InetSocketAddress(port);
+        }
+        return new InetSocketAddress(host, port);
+    }
+
+    private String hostOrWildcard(String host)
+    {
+        if (host == null || host.isBlank()) {
+            return "0.0.0.0";
+        }
+        return host;
+    }
+
+    private boolean allowHostIncrement(String host)
+    {
+        return !isWildcardHost(host);
+    }
+
+    private boolean isWildcardHost(String host)
+    {
+        if (host == null) {
+            return true;
+        }
+        String trimmed = host.trim();
+        return trimmed.isEmpty() || "0.0.0.0".equals(trimmed) || "::".equals(trimmed);
+    }
+
+    private String incrementHostValue(String host)
+    {
+        if (host == null || host.isBlank()) {
+            return host;
+        }
+        if ("0.0.0.0".equals(host.trim())) {
+            return host;
+        }
+        String ipv4 = incrementIpv4(host);
+        if (ipv4 != null) {
+            return ipv4;
+        }
+        Matcher matcher = TRAILING_NUMBER.matcher(host);
+        if (matcher.matches()) {
+            String prefix = matcher.group(1);
+            String digits = matcher.group(2);
+            long number = Long.parseLong(digits);
+            String incremented = String.format("%0" + digits.length() + "d", number + 1);
+            return prefix + incremented;
+        }
+        return host;
+    }
+
+    private String incrementIpv4(String host)
+    {
+        String[] parts = host.split("\\.");
+        if (parts.length != 4) {
+            return null;
+        }
+        int[] values = new int[4];
+        for (int i = 0; i < 4; i++) {
+            try {
+                values[i] = Integer.parseInt(parts[i]);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            if (values[i] < 0 || values[i] > 255) {
+                return null;
+            }
+        }
+        int combined = ((values[0] & 0xff) << 24) | ((values[1] & 0xff) << 16)
+                | ((values[2] & 0xff) << 8) | (values[3] & 0xff);
+        if (combined == 0xffffffff) {
+            return host;
+        }
+        combined += 1;
+        int a = (combined >> 24) & 0xff;
+        int b = (combined >> 16) & 0xff;
+        int c = (combined >> 8) & 0xff;
+        int d = combined & 0xff;
+        return a + "." + b + "." + c + "." + d;
+    }
+
+    private record ResolvedEndpoint(String host, int port)
+    {
+        private ResolvedEndpoint
+        {
+            if (port < 0 || port > MAX_PORT) {
+                throw new IllegalArgumentException("Port out of range: " + port);
+            }
+        }
+    }
+}

--- a/can-cache-application/src/main/java/com/can/metric/MetricsReporter.java
+++ b/can-cache-application/src/main/java/com/can/metric/MetricsReporter.java
@@ -2,6 +2,7 @@ package com.can.metric;
 
 import com.can.cluster.ClusterState;
 import com.can.config.AppProperties;
+import com.can.config.PortAllocator;
 import io.quarkus.runtime.Startup;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
@@ -15,6 +16,7 @@ import org.jboss.logging.Logger;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -49,27 +51,42 @@ public class MetricsReporter implements AutoCloseable
     public MetricsReporter(MetricsRegistry registry,
                            AppProperties properties,
                            ClusterState clusterState,
-                           Vertx vertx)
+                           Vertx vertx,
+                           PortAllocator portAllocator)
     {
         this(registry,
                 properties.metrics(),
                 clusterState != null ? clusterState::localNodeId : () -> "unknown",
+                resolveMetricsHost(portAllocator),
+                resolveMetricsPort(portAllocator),
                 vertx);
     }
 
     MetricsReporter(MetricsRegistry registry,
                     AppProperties.Metrics metricsConfig,
                     Supplier<String> nodeIdSupplier,
+                    String resolvedHost,
+                    int resolvedPort,
                     Vertx vertx)
     {
         this.registry = registry;
         this.nodeIdSupplier = nodeIdSupplier != null ? nodeIdSupplier : () -> "unknown";
         this.replicationRole = sanitizeLabelValue(metricsConfig.replicationRole());
         this.metricsPath = normalisePath(metricsConfig.endpointPath());
-        this.listenHost = metricsConfig.endpointHost();
-        this.listenPort = metricsConfig.endpointPort();
+        this.listenHost = resolvedHost != null ? resolvedHost : metricsConfig.endpointHost();
+        this.listenPort = resolvedPort;
         this.enabled = metricsConfig.endpointEnabled();
         this.vertx = vertx;
+    }
+
+    private static String resolveMetricsHost(PortAllocator portAllocator)
+    {
+        return Objects.requireNonNull(portAllocator, "portAllocator").metricsHost();
+    }
+
+    private static int resolveMetricsPort(PortAllocator portAllocator)
+    {
+        return Objects.requireNonNull(portAllocator, "portAllocator").metricsPort();
     }
 
     @PostConstruct

--- a/can-cache-application/src/main/java/com/can/net/CanCachedServer.java
+++ b/can-cache-application/src/main/java/com/can/net/CanCachedServer.java
@@ -2,6 +2,7 @@ package com.can.net;
 
 import com.can.cluster.ClusterClient;
 import com.can.config.AppProperties;
+import com.can.config.PortAllocator;
 import com.can.constants.CanCachedProtocol;
 import com.can.core.CacheEngine;
 import com.can.core.StoredValueCodec;
@@ -50,6 +51,8 @@ public class CanCachedServer implements AutoCloseable
     private final int maxItemSize;
     private final int maxCasRetries;
     private final CacheEngine<String, String> localEngine;
+    private final String listenHost;
+    private final int listenPort;
 
     private final AtomicLong casCounter = new AtomicLong(1L);
     private final AtomicLong cmdGet = new AtomicLong();
@@ -73,7 +76,8 @@ public class CanCachedServer implements AutoCloseable
     public CanCachedServer(Vertx vertx,
                            ClusterClient clusterClient,
                            AppProperties properties,
-                           CacheEngine<String, String> localEngine)
+                           CacheEngine<String, String> localEngine,
+                           PortAllocator portAllocator)
     {
         this.vertx = Objects.requireNonNull(vertx, "vertx");
         this.clusterClient = Objects.requireNonNull(clusterClient, "clusterClient");
@@ -82,14 +86,17 @@ public class CanCachedServer implements AutoCloseable
         this.maxItemSize = Math.max(1, cancacheConfig.maxItemSizeBytes());
         this.maxCasRetries = Math.max(1, cancacheConfig.maxCasRetries());
         this.localEngine = Objects.requireNonNull(localEngine, "localEngine");
+        Objects.requireNonNull(portAllocator, "portAllocator");
+        this.listenHost = portAllocator.networkHost();
+        this.listenPort = portAllocator.networkPort();
     }
 
     @PostConstruct
     void start()
     {
         NetServerOptions options = new NetServerOptions()
-                .setHost(networkConfig.host())
-                .setPort(networkConfig.port())
+                .setHost(listenHost != null ? listenHost : networkConfig.host())
+                .setPort(listenPort)
                 .setTcpNoDelay(true)
                 .setReuseAddress(true)
                 .setAcceptBacklog(Math.max(1, networkConfig.backlog()));
@@ -103,7 +110,8 @@ public class CanCachedServer implements AutoCloseable
         }
 
         running = true;
-        LOG.infof("cancached-compatible server listening on %s:%d", networkConfig.host(), netServer.actualPort());
+        String host = listenHost != null ? listenHost : networkConfig.host();
+        LOG.infof("cancached-compatible server listening on %s:%d", host, netServer.actualPort());
         removalSubscription = localEngine.onRemoval(key -> decrementCurrItems());
     }
 
@@ -758,7 +766,7 @@ public class CanCachedServer implements AutoCloseable
 
     public int port()
     {
-        return netServer != null ? netServer.actualPort() : networkConfig.port();
+        return netServer != null ? netServer.actualPort() : listenPort;
     }
 
     @PreDestroy

--- a/can-cache-application/src/test/java/com/can/metric/MetricsComponentsTest.java
+++ b/can-cache-application/src/test/java/com/can/metric/MetricsComponentsTest.java
@@ -83,7 +83,8 @@ class MetricsComponentsTest
 
             Vertx vertx = Vertx.vertx();
             FakeMetricsConfig config = new FakeMetricsConfig();
-            MetricsReporter reporter = new MetricsReporter(registry, config, () -> "node-1", vertx);
+            MetricsReporter reporter = new MetricsReporter(registry, config, () -> "node-1",
+                    config.endpointHost(), config.endpointPort(), vertx);
 
             try
             {
@@ -121,7 +122,8 @@ class MetricsComponentsTest
             Vertx vertx = Vertx.vertx();
             FakeMetricsConfig config = new FakeMetricsConfig();
             config.enabled = false;
-            MetricsReporter reporter = new MetricsReporter(registry, config, () -> "node-1", vertx);
+            MetricsReporter reporter = new MetricsReporter(registry, config, () -> "node-1",
+                    config.endpointHost(), config.endpointPort(), vertx);
             try
             {
                 reporter.start();


### PR DESCRIPTION
## Summary
- extend the port allocator to retry sequential host/port combinations and publish the resolved endpoints for network, replication, and metrics components
- bind runtime servers to the allocator's resolved hosts/ports and reuse the adjusted advertise host during coordination announcements
- update the metrics reporter and its tests to accept the resolved host alongside the chosen port

## Testing
- ./mvnw -pl can-cache-application test *(fails: container JDK lacks support for release 24)*

------
https://chatgpt.com/codex/tasks/task_e_68d9995402c8832397afd587c54c5492